### PR TITLE
PublicKey derivation from PrivateKeys

### DIFF
--- a/lib/rbnacl/keys/public_key.rb
+++ b/lib/rbnacl/keys/public_key.rb
@@ -7,13 +7,26 @@ module Crypto
     # The size of the key, in bytes
     SIZE = Crypto::NaCl::PUBLICKEYBYTES
 
-    def initialize(public_key)
-      @public_key = public_key
+    # Initializes a new PublicKey for key operations.
+    #
+    # Takes the (optionally encoded) public key bytes.  This can be shared with
+    # many people and used to establish key pairs with their private key, for
+    # the exchanging of messages using a Crypto::Box
+    #
+    # @param public_key [String] The public key
+    # @param key_encoding [Symbol] The encoding of the key
+    #
+    # @raise [ArgumentError] If the key is not valid after decoding.
+    #
+    # @return A new PublicKey
+    def initialize(public_key, key_encoding = :raw)
+      @public_key = Crypto::Encoder[key_encoding].decode(public_key)
+
       raise ArgumentError, "PublicKey must be #{SIZE} bytes long" unless valid?
     end
 
     def inspect
-      "#<Crypto::PublicKey:#{to_hex}>"
+      "#<Crypto::PublicKey:#{to_s(:hex)}>"
     end
 
     # The raw bytes of the key
@@ -22,13 +35,15 @@ module Crypto
     def to_bytes
       @public_key
     end
-    alias_method :to_s, :to_bytes
 
-    # hex encoding of the key
+    # Return a string representation of this key, possibly encoded into a
+    # given serialization format.
     #
-    # @return [String] the key, hex encoded.
-    def to_hex
-      to_bytes.unpack("H*").first
+    # @param encoding [String] string encoding format in which to encode the key
+    #
+    # @return [String] key encoded in the specified format
+    def to_s(encoding = :raw)
+      Encoder[encoding].encode(to_bytes)
     end
 
     # Is the given key possibly a valid public key?

--- a/spec/rbnacl/keys/private_key_spec.rb
+++ b/spec/rbnacl/keys/private_key_spec.rb
@@ -2,7 +2,11 @@ require 'spec_helper'
 
 describe Crypto::PrivateKey do
   let (:bobsk) { "]\xAB\b~bJ\x8AKy\xE1\x7F\x8B\x83\x80\x0E\xE6o;\xB1)&\x18\xB6\xFD\x1C/\x8B'\xFF\x88\xE0\xEB" } # from the nacl distribution
+  let (:bobsk_hex) { Crypto::Encoder[:hex].encode(bobsk) } # from the nacl distribution
+  let(:bobpk) { "\xDE\x9E\xDB}{}\xC1\xB4\xD3[a\xC2\xEC\xE457?\x83C\xC8[xgM\xAD\xFC~\x14o\x88+O" }
   let (:sk) { Crypto::PrivateKey.new(bobsk)  }
+  let (:sk_hex) { Crypto::PrivateKey.new(bobsk_hex, :hex)  }
+
   context "generate" do
     let(:secret_key) { Crypto::PrivateKey.generate }
 
@@ -19,11 +23,23 @@ describe Crypto::PrivateKey do
     it "accepts a valid key" do
       expect { Crypto::PrivateKey.new(bobsk) }.not_to raise_error(ArgumentError)
     end
+    it "accepts a hex encoded key" do
+      expect { Crypto::PrivateKey.new(bobsk_hex, :hex) }.not_to raise_error(ArgumentError)
+    end
     it "rejects a nil key" do
       expect { Crypto::PrivateKey.new(nil) }.to raise_error(ArgumentError)
     end
     it "rejects a short key" do
       expect { Crypto::PrivateKey.new("short") }.to raise_error(ArgumentError)
+    end
+  end
+
+  context "public_key" do
+    it "returns a public key" do
+      sk.public_key.should be_a Crypto::PublicKey
+    end
+    it "returns the correct public key" do
+      sk.public_key.to_bytes.should eql bobpk
     end
   end
 
@@ -44,11 +60,18 @@ describe Crypto::PrivateKey do
     it "returns the bytes of the key" do
       sk.to_bytes.should eq bobsk
     end
+
+    it "returns the bytes of the key after being passed as hex" do
+      sk_hex.to_bytes.should eq bobsk
+    end
   end
 
-  context "#to_hex" do
+  context "#to_s" do
     it "returns the bytes of the key hex encoded" do
-      sk.to_hex.should eq bobsk.unpack('H*').first
+      sk.to_s(:hex).should eq bobsk_hex
+    end
+    it "returns the raw bytes of the key" do
+      sk.to_s.should eq bobsk
     end
   end
 end

--- a/spec/rbnacl/keys/public_key_spec.rb
+++ b/spec/rbnacl/keys/public_key_spec.rb
@@ -2,10 +2,15 @@ require 'spec_helper'
 
 describe Crypto::PublicKey do
   let (:alicepk) { "\x85 \xF0\t\x890\xA7Tt\x8B}\xDC\xB4>\xF7Z\r\xBF:\r&8\x1A\xF4\xEB\xA4\xA9\x8E\xAA\x9BNj"  } # from the nacl distribution
+  let (:alicepk_hex) { Crypto::Encoder[:hex].encode(alicepk)  }
   let (:pk) { Crypto::PublicKey.new(alicepk) }
+  let (:pk_hex) { Crypto::PublicKey.new(alicepk_hex, :hex) }
   context "new" do
     it "accepts a valid key" do
       expect { Crypto::PublicKey.new(alicepk) }.not_to raise_error(ArgumentError)
+    end
+    it "accepts a valid key in hex" do
+      expect { Crypto::PublicKey.new(alicepk_hex, :hex) }.not_to raise_error(ArgumentError)
     end
     it "rejects a nil key" do
       expect { Crypto::PublicKey.new(nil) }.to raise_error(ArgumentError)
@@ -31,11 +36,17 @@ describe Crypto::PublicKey do
     it "returns the bytes of the key" do
       pk.to_bytes.should eq alicepk
     end
+    it "returns the bytes of the key" do
+      pk_hex.to_bytes.should eq alicepk
+    end
   end
 
-  context "#to_hex" do
+  context "#to_s" do
+    it "returns the bytes of the key" do
+      pk.to_s.should eq alicepk
+    end
     it "returns the bytes of the key hex encoded" do
-      pk.to_hex.should eq alicepk.unpack('H*').first
+      pk.to_s(:hex).should eq alicepk_hex
     end
   end
 end


### PR DESCRIPTION
This commit mostly adds the derivation of the PublicKey from the
PrivateKey by the newly exposed Scalar functions.  However, it also
takes the opportunity to harmonise the interface with the SigningKey and
VerifyKey, accepting encoded keys, and returning them via the #to_s
function.

Fixes #14
