### PR TITLE
Crypto::Serializable

### DIFF
--- a/lib/rbnacl.rb
+++ b/lib/rbnacl.rb
@@ -15,6 +15,7 @@ end
 
 require "rbnacl/nacl"
 require "rbnacl/version"
+require "rbnacl/serializable"
 require "rbnacl/keys/key_comparator"
 require "rbnacl/keys/private_key"
 require "rbnacl/keys/public_key"

--- a/lib/rbnacl/keys/private_key.rb
+++ b/lib/rbnacl/keys/private_key.rb
@@ -10,6 +10,7 @@ module Crypto
   # SecretBox, which does symmetric encryption.
   class PrivateKey
     include KeyComparator
+    include Serializable
 
     # The size of the key, in bytes
     BYTES = Crypto::NaCl::SECRETKEYBYTES
@@ -43,28 +44,11 @@ module Crypto
       new(sk)
     end
 
-    # Inspect this key
-    #
-    # @return [String] a string representing this key
-    def inspect
-      "#<Crypto::PrivateKey:#{to_s(:hex)}>" # a bit dangerous, but okay.
-    end
-
     # The raw bytes of the key
     #
     # @return [String] the raw bytes.
     def to_bytes
       @private_key
-    end
-    
-    # Return a string representation of this key, possibly encoded into a
-    # given serialization format.
-    #
-    # @param encoding [String] string encoding format in which to encode the key
-    #
-    # @return [String] key encoded in the specified format
-    def to_s(encoding = :raw)
-      Encoder[encoding].encode(to_bytes)
     end
 
     # the public key associated with this private key

--- a/lib/rbnacl/keys/public_key.rb
+++ b/lib/rbnacl/keys/public_key.rb
@@ -5,6 +5,7 @@ module Crypto
   # functions for working with it.
   class PublicKey
     include KeyComparator
+    include Serializable
 
     # The size of the key, in bytes
     BYTES = Crypto::NaCl::PUBLICKEYBYTES
@@ -26,28 +27,11 @@ module Crypto
       Util.check_length(@public_key, BYTES, "Public key")
     end
 
-    # Inspect this key
-    #
-    # @return [String] a string representing this key
-    def inspect
-      "#<Crypto::PublicKey:#{to_s(:hex)}>"
-    end
-
     # The raw bytes of the key
     #
     # @return [String] the raw bytes.
     def to_bytes
       @public_key
-    end
-
-    # Return a string representation of this key, possibly encoded into a
-    # given serialization format.
-    #
-    # @param encoding [String] string encoding format in which to encode the key
-    #
-    # @return [String] key encoded in the specified format
-    def to_s(encoding = :raw)
-      Encoder[encoding].encode(to_bytes)
     end
   end
 end

--- a/lib/rbnacl/keys/signing_key.rb
+++ b/lib/rbnacl/keys/signing_key.rb
@@ -18,6 +18,7 @@ module Crypto
   # leak enough information to recover the private key.
   class SigningKey
     include KeyComparator
+    include Serializable
 
     attr_reader :verify_key
 
@@ -68,22 +69,5 @@ module Crypto
     #
     # @return [String] seed used to create this key
     def to_bytes; @seed; end
-
-    # Return a string representation of this key, possibly encoded into a
-    # given serialization format.
-    #
-    # @param encoding [String] string encoding format in which to encode the key
-    #
-    # @return [String] key encoded in the specified format
-    def to_s(encoding = :raw)
-      Encoder[encoding].encode(to_bytes)
-    end
-
-    # Inspect this key
-    #
-    # @return [String] a string representing this key
-    def inspect
-      "#<#{self.class}:#{to_s(:hex)}>"
-    end
   end
 end

--- a/lib/rbnacl/keys/verify_key.rb
+++ b/lib/rbnacl/keys/verify_key.rb
@@ -10,6 +10,8 @@ module Crypto
   # the SigningKey documentation.
   class VerifyKey
     include KeyComparator
+    include Serializable
+
     # Create a new VerifyKey object from a serialized public key. The key can
     # be decoded from any serialization format supported by the
     # Crypto::Encoding system.
@@ -69,22 +71,5 @@ module Crypto
     #
     # @return [String] raw key as bytes
     def to_bytes; @key; end
-
-    # Return a string representation of this key, possibly encoded into a
-    # given serialization format.
-    #
-    # @param encoding [Symbol] string encoding format in which to encode the key
-    #
-    # @return [String] key encoded in the specified format
-    def to_s(encoding = :raw)
-      Encoder[encoding].encode(to_bytes)
-    end
-
-    # Inspect this key
-    #
-    # @return [String] a string representing this key
-    def inspect
-      "#<#{self.class}:#{to_s(:hex)}>"
-    end
   end
 end

--- a/lib/rbnacl/point.rb
+++ b/lib/rbnacl/point.rb
@@ -15,6 +15,7 @@ module Crypto
   # keys from private keys.
   class Point
     include KeyComparator
+    include Serializable
 
     # Creates a new Point from the given serialization
     #
@@ -52,24 +53,6 @@ module Crypto
     #
     # @return [String] 32-byte string representing this point
     def to_bytes; @point; end
-
-    # Return a string representation of this point, possibly encoded into a
-    # given serialization format.
-    #
-    # @param encoding [String] string encoding format in which to encode the point
-    #
-    # @return [String] point encoded in the specified format
-    def to_s(encoding = :raw)
-      Encoder[encoding].encode(to_bytes)
-    end
-    alias_method :to_str, :to_s
-
-    # Inspect this point
-    #
-    # @return [String] a string representing this point
-    def inspect
-      "#<#{self.class}:#{to_s(:hex)}>"
-    end
 
     @base_point = Point.new(STANDARD_GROUP_ELEMENT, :hex)
 

--- a/lib/rbnacl/serializable.rb
+++ b/lib/rbnacl/serializable.rb
@@ -1,0 +1,22 @@
+module Crypto
+  # Serialization features shared across all "key-like" classes
+  module Serializable
+    # Return a string representation of this key, possibly encoded into a
+    # given serialization format.
+    #
+    # @param encoding [String] string encoding format in which to encode the key
+    #
+    # @return [String] key encoded in the specified format
+    def to_s(encoding = :raw)
+      Encoder[encoding].encode(to_bytes)
+    end
+    alias_method :to_str, :to_s
+
+    # Inspect this key
+    #
+    # @return [String] a string representing this key
+    def inspect
+      "#<#{self.class}:#{to_s(:hex)[0,8]}>"
+    end
+  end
+end


### PR DESCRIPTION
This provides a module-based (as opposed to inheritance-based) approach to serializing key-like things, including Crypto::Point.

Inheritance is cool and all, but I'm not sure it's the best choice here. I kind of like modules in this application. Not sure "Serializable" is the best name but feel free to bikeshed all over that ;)
