### PR TITLE
Allow strings of arbitrary bytes to be hashed

### DIFF
--- a/lib/rbnacl/nacl.rb
+++ b/lib/rbnacl/nacl.rb
@@ -33,12 +33,12 @@ module Crypto
     SHA256BYTES = 32
     wrap_nacl_function :crypto_hash_sha256,
                        :crypto_hash_sha256_ref,
-                       [:pointer, :string, :long_long]
+                       [:pointer, :pointer, :long_long]
 
     SHA512BYTES = 64
     wrap_nacl_function :crypto_hash_sha512,
                        :crypto_hash_sha512_ref,
-                       [:pointer, :string, :long_long]
+                       [:pointer, :pointer, :long_long]
 
     PUBLICKEYBYTES = 32
     SECRETKEYBYTES = 32

--- a/spec/rbnacl/hash_spec.rb
+++ b/spec/rbnacl/hash_spec.rb
@@ -24,6 +24,10 @@ describe Crypto::Hash do
     it "calculates the correct hash for an empty string and returns it in hex" do
       Crypto::Hash.sha256("", :hex).should eq empty_string_hash_hex
     end
+
+    it "doesn't raise on a null byte" do
+      expect { Crypto::Hash.sha256("\0") }.to_not  raise_error(/ArgumentError: string contains null byte/)
+    end
   end
 
   context "sha512" do
@@ -47,6 +51,10 @@ describe Crypto::Hash do
 
     it "calculates the correct hash for an empty string and returns it in hex" do
       Crypto::Hash.sha512("", :hex).should eq empty_string_hash_hex
+    end
+
+    it "doesn't raise on a null byte" do
+      expect { Crypto::Hash.sha512("\0") }.to_not  raise_error(/ArgumentError: string contains null byte/)
     end
   end
 end


### PR DESCRIPTION
Some versions of FFI barf on null bytes with a :string type

Fixes #44
