### PR TITLE
Support sodium_init()

### DIFF
--- a/lib/rbnacl.rb
+++ b/lib/rbnacl.rb
@@ -42,5 +42,8 @@ require "rbnacl/point"
 require "rbnacl/random_nonce_box"
 require "rbnacl/test_vectors"
 
+# Select platform-optimized versions of algorithms
+Thread.exclusive { RbNaCl::NaCl.sodium_init }
+
 # Perform self test on load
 require "rbnacl/self_test"

--- a/lib/rbnacl/nacl.rb
+++ b/lib/rbnacl/nacl.rb
@@ -46,6 +46,8 @@ module RbNaCl
       eos
     end
 
+    attach_function :sodium_init, [], :int
+
     SHA256BYTES = 32
     wrap_nacl_function :crypto_hash_sha256,
                        :crypto_hash_sha256_ref,


### PR DESCRIPTION
Automatically call sodium_init() on startup in a Thread.exclusive block,
selecting the best available ciphers for the platform.
