### PR TITLE
Fix method name to convert binary to hex in Serializable module

### DIFF
--- a/lib/rbnacl/serializable.rb
+++ b/lib/rbnacl/serializable.rb
@@ -9,7 +9,7 @@ module RbNaCl
     #
     # @return [String] a string representing this key
     def inspect
-      "#<#{self.class}:#{Util.bytes2hex(to_bytes)[0,8]}>"
+      "#<#{self.class}:#{Util.bin2hex(to_bytes)[0,8]}>"
     end
   end
 end


### PR DESCRIPTION
`Util.bytes2hex` doesn't exits, it's called `Util.bin2hex`.
