### PR TITLE
Serialization specs (fixes #72)

### DIFF
--- a/spec/rbnacl/keys/private_key_spec.rb
+++ b/spec/rbnacl/keys/private_key_spec.rb
@@ -60,4 +60,6 @@ describe RbNaCl::PrivateKey do
     let(:key_bytes) { subject.to_bytes }
     let(:other_key) { described_class.new(bobpk) }
   end
+
+  include_examples "serializable"
 end

--- a/spec/rbnacl/keys/public_key_spec.rb
+++ b/spec/rbnacl/keys/public_key_spec.rb
@@ -37,4 +37,6 @@ describe RbNaCl::PublicKey do
     let(:key_bytes) { subject.to_bytes }
     let(:other_key) { described_class.new(alicepk.succ) }
   end
+
+  include_examples "serializable"
 end

--- a/spec/rbnacl/keys/signing_key_spec.rb
+++ b/spec/rbnacl/keys/signing_key_spec.rb
@@ -25,4 +25,6 @@ describe RbNaCl::SigningKey do
     let(:key)       { described_class.new(key_bytes) }
     let(:other_key) { described_class.new("B"*32) }
   end
+
+  include_examples "serializable"
 end

--- a/spec/rbnacl/keys/verify_key_spec.rb
+++ b/spec/rbnacl/keys/verify_key_spec.rb
@@ -34,4 +34,6 @@ describe RbNaCl::VerifyKey do
     let(:key)       { described_class.new(verify_key) }
     let(:other_key) { described_class.new("B"*32) }
   end
+
+  include_examples "serializable"
 end

--- a/spec/rbnacl/point_spec.rb
+++ b/spec/rbnacl/point_spec.rb
@@ -22,4 +22,6 @@ describe RbNaCl::Point do
   it "serializes to bytes" do
     subject.to_bytes.should eq bob_public
   end
+
+  include_examples "serializable"
 end

--- a/spec/shared/serializable.rb
+++ b/spec/shared/serializable.rb
@@ -1,0 +1,17 @@
+# encoding: binary
+
+shared_examples "serializable" do
+  context "serialization" do
+    it "supports #to_s" do
+      expect(subject.to_s).to be_a String
+    end
+
+    it "supports #to_str" do
+      expect(subject.to_str).to be_a String
+    end
+
+    it "supports #inspect" do
+      expect(subject.inspect).to be_a String
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,7 @@ require 'rbnacl'
 require 'shared/box'
 require 'shared/authenticator'
 require 'shared/key_equality'
+require 'shared/serializable'
 
 def vector(name)
   [RbNaCl::TestVectors[name]].pack("H*")


### PR DESCRIPTION
This checks that all classes that include Serializable can be serialized using
the following methods:
- #to_s
- #to_str
- #inspect
