### PR TITLE
Rename Poly1305 => RbNaCl::OneTimeAuths::Poly1305

### DIFF
--- a/lib/rbnacl.rb
+++ b/lib/rbnacl.rb
@@ -50,7 +50,7 @@ module RbNaCl
   require "rbnacl/group_elements/curve25519"
 
   # One-time Authentication: Poly1305
-  require "rbnacl/authenticators/poly1305"
+  require "rbnacl/one_time_auths/poly1305"
 
   # Hash functions: SHA256/512 and Blake2b
   require "rbnacl/hash"
@@ -72,7 +72,7 @@ module RbNaCl
   SigningKey   = Signatures::Ed25519::SigningKey
   VerifyKey    = Signatures::Ed25519::VerifyKey
   GroupElement = GroupElements::Curve25519
-  OneTimeAuth  = Authenticators::Poly1305
+  OneTimeAuth  = OneTimeAuths::Poly1305
 end
 
 # Select platform-optimized versions of algorithms

--- a/lib/rbnacl/one_time_auths/poly1305.rb
+++ b/lib/rbnacl/one_time_auths/poly1305.rb
@@ -1,6 +1,6 @@
 # encoding: binary
 module RbNaCl
-  module Authenticators
+  module OneTimeAuths
     # Computes an authenticator using poly1305
     #
     # The authenticator can be used at a later time to verify the provenance of
@@ -28,7 +28,7 @@ module RbNaCl
       sodium_function :onetimeauth_poly1305,
                       :crypto_onetimeauth_poly1305,
                       [:pointer, :pointer, :ulong_long, :pointer]
-      
+
       sodium_function :onetimeauth_poly1305_verify,
                       :crypto_onetimeauth_poly1305_verify,
                       [:pointer, :pointer, :ulong_long, :pointer]


### PR DESCRIPTION
cc @namelessjon

This follows the naming convention from the C source code.

"OneTimeAuths" seems a bit silly but it is more consistent. Plus it's not a name
that end users will have to deal with directly (at least in a typical case)
