### PR TITLE
Support short Blake2b keys (fixes #87)

### DIFF
--- a/lib/rbnacl/hash/blake2b.rb
+++ b/lib/rbnacl/hash/blake2b.rb
@@ -36,7 +36,7 @@ module RbNaCl
       def initialize(opts = {})
         @key = opts.fetch(:key, nil)
         @key_size = @key ? @key.bytesize : 0
-        raise LengthError, "Invalid key size" if (@key_size != 0) && (@key_size < KEYBYTES_MIN || @key_size > KEYBYTES_MAX) 
+        raise LengthError, "Invalid key size" if @key_size > KEYBYTES_MAX
 
         @digest_size = opts.fetch(:digest_size, BYTES_MAX)
         raise LengthError, "Invalid digest size" if @digest_size < BYTES_MIN || @digest_size > BYTES_MAX

--- a/spec/rbnacl/hash/blake2b_spec.rb
+++ b/spec/rbnacl/hash/blake2b_spec.rb
@@ -20,7 +20,13 @@ describe RbNaCl::Hash::Blake2b do
     let(:reference_string_hash) { vector :blake2b_keyed_digest }
 
     it "calculates keyed hashes correctly" do
-      RbNaCl::Hash.blake2b(reference_string, :key => reference_key).should eq reference_string_hash
+      RbNaCl::Hash.blake2b(reference_string, key: reference_key).should eq reference_string_hash
+    end
+
+    it "supports short keys" do
+      expect do
+        RbNaCl::Hash.blake2b(reference_string, key: "X")
+      end.to_not raise_exception
     end
   end
 end


### PR DESCRIPTION
Removes the Blake2b KEYBYTES_MIN check, since its value does not match the minimum specified in the Blake2b paper
