### PR TITLE
Improve libsodium version API and check

### DIFF
--- a/lib/rbnacl.rb
+++ b/lib/rbnacl.rb
@@ -1,6 +1,7 @@
 # encoding: binary
 require "rbnacl/version"
 require "rbnacl/sodium"
+require "rbnacl/sodium/version"
 require "rbnacl/serializable"
 require "rbnacl/key_comparator"
 require "rbnacl/auth"
@@ -11,12 +12,6 @@ require "rbnacl/test_vectors"
 require "rbnacl/init"
 
 module RbNaCl
-  REQUIRED_LIBSODIUM_VERSION = "0.4.5"
-
-  if Util.sodium_version_string < REQUIRED_LIBSODIUM_VERSION
-    raise "Sorry, you need to install libsodium #{REQUIRED_LIBSODIUM_VERSION}+. You have #{Util.sodium_version_string} installed"
-  end
-
   # Oh no, something went wrong!
   #
   # This indicates a failure in the operation of a cryptographic primitive such

--- a/lib/rbnacl/sodium/version.rb
+++ b/lib/rbnacl/sodium/version.rb
@@ -1,0 +1,23 @@
+require 'rbnacl/sodium'
+
+module RbNaCl
+  module Sodium
+    module Version
+      MINIMUM_LIBSODIUM_VERSION = "0.4.3"
+
+      extend Sodium
+      attach_function :sodium_version_string, [], :string
+
+      STRING = sodium_version_string
+      MAJOR, MINOR, PATCH = STRING.split(".").map(&:to_i)
+
+      installed_version = [MAJOR, MINOR, PATCH]
+      minimum_version   = MINIMUM_LIBSODIUM_VERSION.split(".").map(&:to_i)
+
+      case installed_version <=> minimum_version
+      when -1
+        raise "Sorry, you need to install libsodium #{MINIMUM_LIBSODIUM_VERSION}+. You have #{Version::STRING} installed"
+      end
+    end
+  end
+end

--- a/lib/rbnacl/util.rb
+++ b/lib/rbnacl/util.rb
@@ -4,8 +4,6 @@ module RbNaCl
   module Util
     extend Sodium
 
-    attach_function :sodium_version_string, [], :string
-
     sodium_function :c_verify16, :crypto_verify_16, [:pointer, :pointer]
     sodium_function :c_verify32, :crypto_verify_32, [:pointer, :pointer]
     module_function


### PR DESCRIPTION
cc @namelessjon 

This now exposes the libsodium version as:
- RbNaCl::Sodium::Version::STRING
- RbNaCl::Sodium::Version::MAJOR
- RbNaCl::Sodium::Version::MINOR
- RbNaCl::Sodium::Version::PATCH

The version check now compares the required version against the installed
version by first parsing them as integers and then using the spaceship operator.

The minimum version of libsodium has been changed to 0.4.3.
