### PR TITLE
Remove non-raising verification functions

### DIFF
--- a/lib/rbnacl.rb
+++ b/lib/rbnacl.rb
@@ -34,6 +34,10 @@ module RbNaCl
   # The signature was forged or otherwise corrupt
   class BadSignatureError < CryptoError; end
 
+  # The authenticator was forged or otherwise corrupt
+  class BadAuthenticatorError < CryptoError; end
+
+
   # Public Key Encryption (Box): Curve25519XSalsa20Poly1305
   require "rbnacl/boxes/curve25519xsalsa20poly1305"
   require "rbnacl/boxes/curve25519xsalsa20poly1305/private_key"

--- a/lib/rbnacl/auth.rb
+++ b/lib/rbnacl/auth.rb
@@ -1,5 +1,6 @@
 # encoding: binary
 module RbNaCl
+
   # Secret Key Authenticators
   #
   # These provide a means of verifying the integrity of a message, but only
@@ -38,6 +39,8 @@ module RbNaCl
     # @param [#to_str] authenticator to be checked
     # @param [#to_str] message the message to be authenticated
     #
+    # @raise [BadAuthenticatorError] if the tag isn't valid
+    #
     # @return [Boolean] Was it valid?
     def self.verify(key, authenticator, message)
       new(key).verify(authenticator, message)
@@ -60,11 +63,13 @@ module RbNaCl
     # @param [#to_str] authenticator to be checked
     # @param [#to_str] message the message to be authenticated
     #
+    # @raise [BadAuthenticatorError] if the tag isn't valid
+    #
     # @return [Boolean] Was it valid?
     def verify(authenticator, message)
       auth = authenticator.to_s
-      return false unless auth.bytesize == tag_bytes
-      verify_message(auth, message)
+      Util.check_length(auth, tag_bytes, "Provided authenticator")
+      verify_message(auth, message) || raise(BadAuthenticatorError, "Invalid authenticator provided, message is corrupt")
     end
 
     # The crypto primitive for this authenticator instance

--- a/lib/rbnacl/self_test.rb
+++ b/lib/rbnacl/self_test.rb
@@ -80,12 +80,14 @@ module RbNaCl
         #:nocov:
       end
 
-      bad_signature = signature[0,63] + '0'
-
-      unless verify_key.verify(bad_signature, message) == false
-        #:nocov:
-        raise SelfTestFailure, "failed to detect an invalid signature"
-        #:nocov:
+      begin
+        passed         = false
+        bad_signature = signature[0,63] + '0'
+        verify_key.verify(bad_signature, message)
+      rescue CryptoError
+        passed = true
+      ensure
+        passed or raise SelfTestFailure, "failed to detect corrupt ciphertext"
       end
     end
 
@@ -117,10 +119,13 @@ module RbNaCl
         #:nocov:
       end
 
-      if authenticator.verify(vector(tag), message + ' ')
-        #:nocov:
-        raise SelfTestFailure, "#{klass} failed to detect invalid authentication tag"
-        #:nocov:
+      begin
+        passed         = false
+        authenticator.verify(vector(tag), message + ' ')
+      rescue CryptoError
+        passed = true
+      ensure
+        passed or raise SelfTestFailure, "failed to detect corrupt ciphertext"
       end
     end
   end

--- a/lib/rbnacl/signatures/ed25519/verify_key.rb
+++ b/lib/rbnacl/signatures/ed25519/verify_key.rb
@@ -33,8 +33,12 @@ module RbNaCl
 
         # Verify a signature for a given message
         #
+        # Raises if the signature is invalid.
+        #
         # @param signature [String] Alleged signature to be checked
         # @param message [String] Message to be authenticated
+        #
+        # @raise [BadSignatureError] if the signature check fails
         #
         # @return [Boolean] was the signature authentic?
         def verify(signature, message)
@@ -45,25 +49,7 @@ module RbNaCl
           buffer = Util.zeros(sig_and_msg.bytesize)
           buffer_len = Util.zeros(FFI::Type::LONG_LONG.size)
 
-          self.class.sign_ed25519_open(buffer, buffer_len, sig_and_msg, sig_and_msg.bytesize, @key)
-        end
-
-        # Verify a signature for a given message or raise exception
-        #
-        # "Dangerous" (but really safer) verify that raises an exception if a
-        # signature check fails. This is probably less likely to go unnoticed than
-        # an improperly checked verify, as you are forced to deal with the
-        # exception explicitly (and failing signature checks are certainly an
-        # exceptional condition!)
-        #
-        # The arguments are otherwise the same as the verify method.
-        #
-        # @param message [String] Message to be authenticated
-        # @param signature [String] Alleged signature to be checked
-        #
-        # @return [true] Will raise BadSignatureError if signature check fails
-        def verify!(message, signature)
-          verify(message, signature) or raise BadSignatureError, "signature was forged/corrupt"
+          self.class.sign_ed25519_open(buffer, buffer_len, sig_and_msg, sig_and_msg.bytesize, @key) || raise(BadSignatureError, "signature was forged/corrupt")
         end
 
         # Return the raw key in byte format

--- a/spec/rbnacl/signatures/ed25519/verify_key_spec.rb
+++ b/spec/rbnacl/signatures/ed25519/verify_key_spec.rb
@@ -13,12 +13,12 @@ describe RbNaCl::VerifyKey do
     subject.verify(signature, message).should be_true
   end
 
-  it "detects bad signatures" do
-    subject.verify(bad_signature, message).should be_false
+  it "raises when asked to verify a bad signature" do
+    expect { subject.verify(bad_signature, message) }.to raise_exception RbNaCl::BadSignatureError
   end
 
-  it "raises when asked to verify with a bang" do
-    expect { subject.verify!(bad_signature, message) }.to raise_exception RbNaCl::BadSignatureError
+  it "raises when asked to verify a short signature" do
+    expect { subject.verify(bad_signature[0,63], message) }.to raise_exception RbNaCl::LengthError
   end
 
   it "serializes to bytes" do

--- a/spec/shared/authenticator.rb
+++ b/spec/shared/authenticator.rb
@@ -53,18 +53,17 @@ shared_examples "authenticator" do
     end
 
     it "fails to validate an invalid authenticator" do
-      described_class.verify(key, tag, message+"\0").should be false
+      expect { described_class.verify(key, tag, message+"\0") }.to raise_error(RbNaCl::BadAuthenticatorError)
     end
 
     it "fails to validate a short authenticator" do
-      described_class.verify(key, tag[0,tag.bytesize - 2], message).should be false
+      expect { described_class.verify(key, tag[0,tag.bytesize - 2], message) }.to raise_error(RbNaCl::LengthError)
     end
 
     it "fails to validate a long authenticator" do
-      described_class.verify(key, tag+"\0", message).should be false
+      expect { described_class.verify(key, tag+"\0", message) }.to raise_error(RbNaCl::LengthError)
     end
   end
-
 
   context "Instance methods" do
     let(:authenticator) { described_class.new(key) }
@@ -81,15 +80,15 @@ shared_examples "authenticator" do
       end
 
       it "fails to validate an invalid authenticator" do
-        authenticator.verify(tag, message+"\0").should be false
+        expect { authenticator.verify(tag, message+"\0") }.to raise_error(RbNaCl::BadAuthenticatorError)
       end
 
       it "fails to validate a short authenticator" do
-        authenticator.verify(tag[0,tag.bytesize - 2], message).should be false
+        expect { authenticator.verify(tag[0,tag.bytesize - 2], message) }.to raise_error(RbNaCl::LengthError)
       end
 
       it "fails to validate a long authenticator" do
-        authenticator.verify(tag+"\0", message).should be false
+        expect { authenticator.verify(tag+"\0", message) }.to raise_error(RbNaCl::LengthError)
       end
     end
   end


### PR DESCRIPTION
Now all three (authenticators, signatures and boxes) will raise if there
are errors in verifying them.  This ensures that errors are dealt with,
or the program comes crashing to a halt.  Self-tests are also updated.
