### PR TITLE
Remove anti-NIST "FUD"

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,41 +214,6 @@ Sure, here you go:
 
 ![Checkmarked Lock](http://i.imgur.com/dwA0Ffi.png)
 
-### Is it full of NSA backdoors?
-
-![No NIST](http://i.imgur.com/HSxeAmp.png)
-
-The design of RbNaCl's primitives is completely free from NIST (and by
-association, NSA) influence, with the following minor exceptions:
-
-* The Poly1305 MAC, used for authenticating integrity of ciphertexts, uses AES
-  as a replaceable component
-* The Ed25519 digital signature algorithm uses SHA-512 for both key derivation
-  and computing message digests
-* APIs are provided to certain NIST hash functions, including SHA-256, SHA-512,
-  and their associated HMAC counterparts
-
-Otherwise, all of the algorithms in NaCl were designed by Dan Bernstein and his
-collaborators.
-
-The design choices in NaCl, particularly in regard to the Curve25519
-Diffie-Hellman function, emphasize security (whereas [NIST curves emphasize
-"performance" at the cost of security][nist-security-dangers]), and "magic
-constants" in NaCl are picked by theorems designed to maximize security.
-The same cannot be said of NIST curves, where the specific origins of certain
-constants are not described by the standards and may be subject to malicious
-influence by the NSA.
-
-It is the opinion of this library's authors that Dan Bernstein is unlikely to be
-subject to NSA influence (although we have no way of actually knowing this).
-
-Dan Bernstein's designs have been well-scrutinized both as part of the [ESTREAM
-Project](https://en.wikipedia.org/wiki/ESTREAM) and the cryptographic community
-as a whole. And despite the emphasis on higher security, NaCl's primitives are
-faster across-the-board than most implementations of the NIST standards.
-
-[nist-security-dangers]: http://www.hyperelliptic.org/tanja/vortraege/20130531.pdf
-
 ## Contributing
 
 * Fork this repository on Github


### PR DESCRIPTION
I'm no fan of NIST, at least when it comes to the specification of cryptographic
standards. They have been the NSA's stooge since the 1987 Computer Security Act
theoretically gave them, and not the NSA, control of these standards. They
subsequently went on to push the (inferior) Digital Signature Algorithm over RSA
signatures, most likely because the NSA was worried about having a standard for
public key encryption which they were incapable of breaking. Rinse, repeat with
Dual_EC_DRBG, a standard intentionally backdoored by the NSA.

This has happened before, and it will all happen again.

That said, perhaps this README isn't the best venue for voicing these concerns.
