### PR TITLE
Add salt/personalisation strings for Blake2b

### DIFF
--- a/lib/rbnacl/hash.rb
+++ b/lib/rbnacl/hash.rb
@@ -52,8 +52,10 @@ module RbNaCl
     # @param [String] data The data, as a collection of bytes
     # @option options [Fixnum]   digest_size Size in bytes (1-64, default 64)
     # @option options [String]   key 64-byte (or less) key for keyed mode
-    # @option options [String]   salt  Provide a salt to support randomised hashing.  This is mixed into the parameters block to start the hashing.
-    # @option options [Personal] personal Provide personalisation string to allow pinning a hash for a particular purpose.  This is mixed into the parameters block to start the hashing
+    # @option options [String]   salt  Provide a salt to support randomised hashing.
+    #                                  This is mixed into the parameters block to start the hashing.
+    # @option options [Personal] personal Provide personalisation string to allow pinning a hash for a particular purpose.
+    #                                     This is mixed into the parameters block to start the hashing
     #
     # @raise [CryptoError] If the hashing fails for some reason.
     #

--- a/lib/rbnacl/hash.rb
+++ b/lib/rbnacl/hash.rb
@@ -50,8 +50,10 @@ module RbNaCl
     # This method returns a 64-byte hash by default.
     #
     # @param [String] data The data, as a collection of bytes
-    # @option options [Fixnum] digest_size Size in bytes (1-64, default 64)
-    # @option options [String] key 64-byte (or less) key for keyed mode
+    # @option options [Fixnum]   digest_size Size in bytes (1-64, default 64)
+    # @option options [String]   key 64-byte (or less) key for keyed mode
+    # @option options [String]   salt  Provide a salt to support randomised hashing.  This is mixed into the parameters block to start the hashing.
+    # @option options [Personal] personal Provide personalisation string to allow pinning a hash for a particular purpose.  This is mixed into the parameters block to start the hashing
     #
     # @raise [CryptoError] If the hashing fails for some reason.
     #

--- a/lib/rbnacl/hash/blake2b.rb
+++ b/lib/rbnacl/hash/blake2b.rb
@@ -26,16 +26,18 @@ module RbNaCl
                        :crypto_generichash_blake2b_salt_personal,
                        [:pointer, :size_t, :pointer, :ulong_long, :pointer, :size_t, :pointer, :pointer]
 
-      EMPTY_PERSONAL = ("\0"*PERSONALBYTES).freeze
-      EMPTY_SALT     = ("\0"*SALTBYTES).freeze
+      EMPTY_PERSONAL = ("\0" * PERSONALBYTES).freeze
+      EMPTY_SALT     = ("\0" * SALTBYTES).freeze
 
       # Create a new Blake2b hash object
       #
       # @param [Hash] opts Blake2b configuration
       # @option opts [String]  :key for Blake2b keyed mode
       # @option opts [Integer] :digest_size size of output digest in bytes
-      # @option opts [String]  :salt  Provide a salt to support randomised hashing.  This is mixed into the parameters block to start the hashing.
-      # @option opts [Personal] :personal Provide personalisation string to allow pinning a hash for a particular purpose.  This is mixed into the parameters block to start the hashing
+      # @option opts [String]  :salt  Provide a salt to support randomised hashing.
+      #                               This is mixed into the parameters block to start the hashing.
+      # @option opts [Personal] :personal Provide personalisation string to allow pinning a hash for a particular purpose.
+      #                                   This is mixed into the parameters block to start the hashing
       #
       # @raise [RbNaCl::LengthError] Invalid length specified for one or more options
       #
@@ -69,7 +71,8 @@ module RbNaCl
       # @return [String] Blake2b digest of the string as raw bytes
       def digest(message)
         digest = Util.zeros(@digest_size)
-        self.class.generichash_blake2b(digest, @digest_size, message, message.bytesize, @key, @key_size, @salt, @personal) || fail(CryptoError, "Hashing failed!")
+        self.class.generichash_blake2b(digest, @digest_size, message, message.bytesize, @key, @key_size, @salt, @personal) ||
+          fail(CryptoError, "Hashing failed!")
         digest
       end
     end

--- a/lib/rbnacl/test_vectors.rb
+++ b/lib/rbnacl/test_vectors.rb
@@ -87,6 +87,27 @@ module RbNaCl
     blake2b_keyed_digest: "142709d62e28fcccd0af97fad0f8465b971e82201dc51070faa0372aa43e9248" \
                               "4be1c1e73ba10906d5d1853db6a4106e0a7bf9800d373d6dee2d46d62ef2a461",
 
+    # Generated using the blake2 reference code
+    blake2b_personal:         "000102030405060708090a0b0c0d0e0f",
+
+    blake2b_personal_digest:  "7c86d3f929c9ac7f08c7940095da7c1cad2cf29db2e7a25fb05d99163e587cbd" \
+                              "f3564e8ce727b734a0559ee76f6ff5aeebd4e1e8872f1829174c9b1a9dab80e3",
+
+    blake2b_salt:             "000102030405060708090a0b0c0d0e0f",
+
+    blake2b_salt_digest:      "16e2e2cfb97e6061bccf2fcc1e605e117dee806c959ef2ad01249d4d12ce98cb" \
+                              "c993f400003ba57449f60a7b071ffdaff9c0acb16891a01a9b397ffe89db96bb",
+
+    blake2b_personal_short:   "0001020304050607",
+
+    blake2b_personal_short_digest:  "41b984967f852308710a6042d25f5faf4a84900b2001039075dab13aecfab7c8" \
+                              "40def9506326563fbb355b3da629181d97d2556e4624711d68f8f655b7cbb435",
+
+    blake2b_salt_short:       "0001020304050607",
+
+    blake2b_salt_short_digest: "873f35a1ca28febc872d6f842a8cd23136f3a2c22c19e8f0dac4cc704ced3371"\
+                              "abe5105f65d344cd48bad8aba755620f63f1e0b35ae4439bf871ffe72485a309",
+
     # scrypt test vectors
     # Taken from http://tools.ietf.org/html/draft-josefsson-scrypt-kdf-01#page-14
     scrypt_password: "4a857e2ee8aa9b6056f2424e84d24a72473378906ee04a46cb05311502d5250b" \

--- a/lib/rbnacl/util.rb
+++ b/lib/rbnacl/util.rb
@@ -60,7 +60,7 @@ module RbNaCl
       if len == n
         message
       elsif len > n
-        raise LengthError, "String too long for zero-padding to #{n} bytes"
+        fail LengthError, "String too long for zero-padding to #{n} bytes"
       else
         message + zeros(n - len)
       end

--- a/lib/rbnacl/util.rb
+++ b/lib/rbnacl/util.rb
@@ -47,6 +47,25 @@ module RbNaCl
       message.slice!(n, message.bytesize - n)
     end
 
+    # Pad a string out to n characters with zeros
+    #
+    # @param [Integer] n The length of the resulting string
+    # @param [String]  message the message to be padded
+    #
+    # @raise [RbNaCl::LengthError] If the string is too long
+    #
+    # @return [String] A string, n bytes long
+    def zero_pad(n, message)
+      len = message.bytesize
+      if len == n
+        message
+      elsif len > n
+        raise LengthError, "String too long for zero-padding to #{n} bytes"
+      else
+        message + zeros(n - len)
+      end
+    end
+
     # Check the length of the passed in string
     #
     # In several places through the codebase we have to be VERY strict with

--- a/spec/rbnacl/hash/blake2b_spec.rb
+++ b/spec/rbnacl/hash/blake2b_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe RbNaCl::Hash::Blake2b do
     end
 
     it "calculates personalised hashes correctly with a short personal" do
-      expect(RbNaCl::Hash.blake2b(reference_string, personal: reference_personal_short )).to eq reference_personal_short_hash
+      expect(RbNaCl::Hash.blake2b(reference_string, personal: reference_personal_short)).to eq reference_personal_short_hash
     end
   end
 
@@ -56,7 +56,7 @@ RSpec.describe RbNaCl::Hash::Blake2b do
     end
 
     it "calculates saltised hashes correctly with a short salt" do
-      expect(RbNaCl::Hash.blake2b(reference_string, salt: reference_salt_short )).to eq reference_salt_short_hash
+      expect(RbNaCl::Hash.blake2b(reference_string, salt: reference_salt_short)).to eq reference_salt_short_hash
     end
   end
 end

--- a/spec/rbnacl/hash/blake2b_spec.rb
+++ b/spec/rbnacl/hash/blake2b_spec.rb
@@ -27,4 +27,36 @@ RSpec.describe RbNaCl::Hash::Blake2b do
       expect { RbNaCl::Hash.blake2b(reference_string, key: "") }.to raise_exception
     end
   end
+
+  context "personalized" do
+    let(:reference_string)              { vector :blake2b_message }
+    let(:reference_personal)            { vector :blake2b_personal }
+    let(:reference_personal_hash)       { vector :blake2b_personal_digest }
+    let(:reference_personal_short)      { vector :blake2b_personal_short }
+    let(:reference_personal_short_hash) { vector :blake2b_personal_short_digest }
+
+    it "calculates personalised hashes correctly" do
+      expect(RbNaCl::Hash.blake2b(reference_string, personal: reference_personal)).to eq reference_personal_hash
+    end
+
+    it "calculates personalised hashes correctly with a short personal" do
+      expect(RbNaCl::Hash.blake2b(reference_string, personal: reference_personal_short )).to eq reference_personal_short_hash
+    end
+  end
+
+  context "salted" do
+    let(:reference_string)              { vector :blake2b_message }
+    let(:reference_salt)            { vector :blake2b_salt }
+    let(:reference_salt_hash)       { vector :blake2b_salt_digest }
+    let(:reference_salt_short)      { vector :blake2b_salt_short }
+    let(:reference_salt_short_hash) { vector :blake2b_salt_short_digest }
+
+    it "calculates saltised hashes correctly" do
+      expect(RbNaCl::Hash.blake2b(reference_string, salt: reference_salt)).to eq reference_salt_hash
+    end
+
+    it "calculates saltised hashes correctly with a short salt" do
+      expect(RbNaCl::Hash.blake2b(reference_string, salt: reference_salt_short )).to eq reference_salt_short_hash
+    end
+  end
 end


### PR DESCRIPTION
They are exposed as options on the hash constructor.  Strings are
zero-padded out to 16 bytes.  If they are not provided then a blank
string is passed into the hash.

Need to add some tests, but I've checked against the sodium vectors at least.