### PR TITLE
Update scrypt name to scryptsalsa208sha256.

### DIFF
--- a/lib/rbnacl/password_hash/scrypt.rb
+++ b/lib/rbnacl/password_hash/scrypt.rb
@@ -20,12 +20,12 @@ module RbNaCl
 
       begin
         sodium_type      :pwhash
-        sodium_primitive :scryptxsalsa208sha256
+        sodium_primitive :scryptsalsa208sha256
 
         sodium_constant :SALTBYTES
 
         sodium_function  :scrypt,
-                         :crypto_pwhash_scryptxsalsa208sha256,
+                         :crypto_pwhash_scryptsalsa208sha256,
                          [:pointer, :ulong_long, :pointer, :ulong_long, :pointer, :ulong_long, :size_t]
 
 


### PR DESCRIPTION
This function used to be named scryptxsalsa208sha256 but has been
renamed to scryptsalsa208sha2560.

See jedisct1/libsodium@bd05b7d292bd05b7d292bd05b7d292

This change happened in libsodium release 0.7.
