### PR TITLE
size_t != unsigned long long, at least on x86

### DIFF
--- a/lib/rbnacl/hash/blake2b.rb
+++ b/lib/rbnacl/hash/blake2b.rb
@@ -22,7 +22,7 @@ module RbNaCl
 
       sodium_function  :generichash_blake2b,
                        :crypto_generichash_blake2b,
-                       [:pointer, :ulong_long, :pointer, :ulong_long, :pointer, :ulong_long]
+                       [:pointer, :size_t, :pointer, :ulong_long, :pointer, :size_t]
 
       # Create a new Blake2b hash object
       #


### PR DESCRIPTION
This was causing a crash on an x86 system I have access to.
