### PR TITLE
fix sodium constant type (size_t instead of ulong_long)

### DIFF
--- a/lib/rbnacl/sodium.rb
+++ b/lib/rbnacl/sodium.rb
@@ -30,7 +30,7 @@ module RbNaCl
 
     def sodium_constant(constant, name=constant)
       fn = "crypto_#{sodium_type}_#{sodium_primitive}_#{constant.to_s.downcase}"
-      attach_function fn, [], :ulong_long
+      attach_function fn, [], :size_t
       self.const_set(name, self.public_send(fn))
     end
 


### PR DESCRIPTION
It seems like libsodium exposes all constants as `size_t` (I checked at least the files `src/libsodium/crypto_box/curve25519xsalsa20poly1305/box_curve25519xsalsa20poly1305_api.c` and `src/libsodium/crypto_generichash/blake2/generichash_blake2_api.c` of libsodium). So this FFI declaration seems wrong and is probably the reason for issue #112.

I haven't actually tested this. @patte Could you test this on your Raspberry Pi?

@tarcieri Does this sound plausible? I don't know a lot about C.
