### PR TITLE
Test both minimum supported and latest released libsodium

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,10 @@ rvm:
   - jruby-head
   - rbx-2
 
+env:
+  - LIBSODIUM_VERSION=1.0.0 # Minimum supported
+  - LIBSODIUM_VERSION=1.0.3 # Latest released
+
 matrix:
   fast_finish: true
   allow_failures:

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ end
 
 group :test do
   gem "coveralls", require: false
-  gem "rbnacl-libsodium"
+  gem "rbnacl-libsodium", ENV["LIBSODIUM_VERSION"]
 end
 
 group :development, :test do


### PR DESCRIPTION
Presently pinned to 1.0.0 and 1.0.3 respectively

@namelessjon I think this is what you were after...