### PR TITLE
Ruby 2.3 compatability

### DIFF
--- a/lib/rbnacl.rb
+++ b/lib/rbnacl.rb
@@ -85,7 +85,8 @@ module RbNaCl
 end
 
 # Select platform-optimized versions of algorithms
-Thread.exclusive { RbNaCl::Init.sodium_init }
+INIT_MUTEX = Mutex.new
+Thread.new { INIT_MUTEX.synchronize { RbNaCl::Init.sodium_init } }
 
 # Perform self test on load
 require "rbnacl/self_test" unless defined?($RBNACL_SELF_TEST) && $RBNACL_SELF_TEST == false


### PR DESCRIPTION
Ruby 2.3 depreciates `Thread.exclusive` in favour of using `Mutex`
objects. `Mutex` has been around since ruby 1.9 so we can use it for all
versions.