### PR TITLE
Remove use of Thread.exclusive when initializing library

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,13 @@
+3.3.0 (2015-12-29)
+------------------
+* [#105](https://github.com/cryptosphere/rbnacl/pull/105)
+  Add salt/personalisation strings for Blake2b.
+  ([@namelessjon])
+
+* [#128](https://github.com/cryptosphere/rbnacl/pull/128)
+  Remove use of Thread.exclusive when initializing library.
+  ([@tarcieri])
+
 3.2.0 (2015-05-31)
 ------------------
 * Fix method signature for blake2b
@@ -59,3 +69,6 @@
 1.0.0 (2013-03-08)
 ------------------
 * Initial release
+
+[@namelessjon]: https://github.com/namelessjon
+[@tarcieri]: https://github.com/tarcieri

--- a/README.md
+++ b/README.md
@@ -55,9 +55,8 @@ For more information on NaCl's goals, see Dan Bernstein's presentation
 You can use RbNaCl anywhere you can get libsodium installed (see below).
 RbNaCl is continuously integration tested on the following Ruby VMs:
 
-* MRI 2.0, 2.1, 2.2
-* JRuby 1.7 (in both 1.8/1.9 mode)
-* Rubinius HEAD (in both 1.8/1.9 mode)
+* MRI 2.0, 2.1, 2.2, 2.3
+* JRuby 1.7, 9000
 
 ## Installation
 

--- a/lib/rbnacl.rb
+++ b/lib/rbnacl.rb
@@ -85,7 +85,7 @@ module RbNaCl
 end
 
 # Select platform-optimized versions of algorithms
-Thread.exclusive { RbNaCl::Init.sodium_init }
+RbNaCl::Init.sodium_init
 
 # Perform self test on load
 require "rbnacl/self_test" unless defined?($RBNACL_SELF_TEST) && $RBNACL_SELF_TEST == false

--- a/lib/rbnacl/version.rb
+++ b/lib/rbnacl/version.rb
@@ -3,5 +3,5 @@
 # NaCl/libsodium for Ruby
 module RbNaCl
   # The library's version
-  VERSION = "3.2.0"
+  VERSION = "3.3.0"
 end


### PR DESCRIPTION
Thread.exclusive is deprecated in Ruby 2.3

We can hopefully rely on require to only run in a single thread at a time