### PR TITLE
Reduce built gem file size

### DIFF
--- a/rbnacl.gemspec
+++ b/rbnacl.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |gem|
   gem.homepage      = "https://github.com/cryptosphere/rbnacl"
   gem.licenses      = ["MIT"]
 
-  gem.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
+  gem.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(spec|images)/}) }
   gem.executables   = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]


### PR DESCRIPTION
Reduce file size by removing tests and images from generated package
Previous gem size:        233KB
With new configuration:  53KB