### PR TITLE
Expose the internal @signing_key value in RbNaCl::Signatures::Ed25519 as #keypair

### DIFF
--- a/lib/rbnacl/signatures/ed25519/signing_key.rb
+++ b/lib/rbnacl/signatures/ed25519/signing_key.rb
@@ -86,6 +86,14 @@ module RbNaCl
           @seed
         end
 
+        # Return the raw 64 byte value of this key
+        #
+        # @return [String] The signature key bytes. Left half is 32-byte
+        #   curve25519 private scalar, right half is 32-byte group element
+        def keypair_bytes
+          @signing_key
+        end
+
         # The crypto primitive this SigningKey class uses for signatures
         #
         # @return [Symbol] The primitive

--- a/spec/rbnacl/signatures/ed25519/signing_key_spec.rb
+++ b/spec/rbnacl/signatures/ed25519/signing_key_spec.rb
@@ -20,6 +20,11 @@ RSpec.describe RbNaCl::SigningKey do
     expect(subject.to_bytes).to eq signing_key
   end
 
+  it "serializes the internal signing key to bytes" do
+    expect(subject.keypair_bytes.length).to eq 64
+    expect(subject.keypair_bytes).to eq "\xB1\x8E\x1D\x00E\x99^\xC3\xD0\x10\xC3\x87\xCC\xFE\xB9\x84\xD7\x83\xAF\x8F\xBB\x0F@\xFA}\xB1&\xD8\x89\xF6\xDA\xDDw\xF4\x8BY\xCA\xED\xA7wQ\xED\x13\x8B\x0E\xC6g\xFFP\xF8v\x8C%\xD4\x83\t\xA8\xF3\x86\xA2\xBA\xD1\x87\xFB"
+  end
+
   include_examples "key equality" do
     let(:key_bytes) { signing_key }
     let(:key)       { described_class.new(key_bytes) }


### PR DESCRIPTION
As per our Twitter DM discussion today. Let me know if you want me to modify anything.  Thanks.