### PR TITLE
Add wrappers for crypto_aead_chacha20poly1305_*

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,14 +13,13 @@ rvm:
   - 2.2.5
   - 2.3.1
   - ruby-head
-  - jruby
   - jruby-9.0.5.0
   - jruby-head
   - rbx-2
 
 env:
   - LIBSODIUM_VERSION=1.0.0 # Minimum supported
-  - LIBSODIUM_VERSION=1.0.8 # Latest released
+  - LIBSODIUM_VERSION=1.0.10 # Latest released
 
 matrix:
   fast_finish: true

--- a/lib/rbnacl.rb
+++ b/lib/rbnacl.rb
@@ -72,6 +72,9 @@ module RbNaCl
   require "rbnacl/hmac/sha512256"
   require "rbnacl/hmac/sha512"
 
+  # AEAD: ChaCha20-Poly1305
+  require "rbnacl/aead/chacha20poly1305"
+
   #
   # Bind aliases used by the public API
   #

--- a/lib/rbnacl.rb
+++ b/lib/rbnacl.rb
@@ -74,6 +74,7 @@ module RbNaCl
 
   # AEAD: ChaCha20-Poly1305
   require "rbnacl/aead/chacha20poly1305"
+  require "rbnacl/aead/chacha20poly1305_ietf"
 
   #
   # Bind aliases used by the public API

--- a/lib/rbnacl.rb
+++ b/lib/rbnacl.rb
@@ -10,6 +10,7 @@ require "rbnacl/random"
 require "rbnacl/simple_box"
 require "rbnacl/test_vectors"
 require "rbnacl/init"
+require "rbnacl/aead/aead"
 
 # NaCl/libsodium for Ruby
 module RbNaCl

--- a/lib/rbnacl/aead/aead.rb
+++ b/lib/rbnacl/aead/aead.rb
@@ -1,0 +1,136 @@
+# encoding: binary
+module RbNaCl
+  module AEAD
+    # Authenticated Encryption with Additional Data
+    #
+    # This construction encrypts a message, and computes an authentication
+    # tag for the encrypted message and some optional additional data
+    #
+    # RbNaCl provides wrappers for both ChaCha20-Poly1305 AEAD implementations
+    # in libsodium: the original, and the IETF version.
+    class GenericAEAD
+      # Number of bytes in a valid key
+      KEYBYTES = 0
+
+      # Number of bytes in a valid nonce
+      NPUBBYTES = 0
+
+      attr_reader :key
+      private :key
+
+      # Create a new AEAD using the IETF chacha20poly1305 construction
+      #
+      # Sets up AEAD with a secret key for encrypting and decrypting messages.
+      #
+      # @param key [String] The key to encrypt and decrypt with
+      #
+      # @raise [RbNaCl::LengthError] on invalid keys
+      #
+      # @return [RbNaCl::AEAD::Chacha20Poly1305IETF] The new AEAD construct, ready to use
+      def initialize(key)
+        @key = Util.check_string(key, key_bytes, "Secret key")
+      end
+
+      # Encrypts and authenticates a message with additional authenticated data
+      #
+      # @param nonce [String] An 8-byte string containing the nonce.
+      # @param message [String] The message to be encrypted.
+      # @param additional_data [String] The additional authenticated data
+      #
+      # @raise [RbNaCl::LengthError] If the nonce is not valid
+      # @raise [RbNaCl::CryptoError] If the ciphertext cannot be authenticated.
+      #
+      # @return [String] The encrypted message with the authenticator tag appended
+      def encrypt(nonce, message, additional_data)
+        Util.check_length(nonce, nonce_bytes, "Nonce")
+
+        ciphertext_len = Util.zeros(1)
+        ciphertext = Util.zeros(message.bytesize + tag_bytes)
+
+        success = do_encrypt(ciphertext, ciphertext_len, nonce, message, additional_data)
+        raise CryptoError, "Encryption failed" unless success
+        ciphertext
+      end
+
+      # Decrypts and verifies an encrypted message with additional authenticated data
+      #
+      # @param nonce [String] An 8-byte string containing the nonce.
+      # @param ciphertext [String] The message to be decrypted.
+      # @param additional_data [String] The additional authenticated data
+      #
+      # @raise [RbNaCl::LengthError] If the nonce is not valid
+      # @raise [RbNaCl::CryptoError] If the ciphertext cannot be authenticated.
+      #
+      # @return [String] The decrypted message
+      def decrypt(nonce, ciphertext, additional_data)
+        Util.check_length(nonce, nonce_bytes, "Nonce")
+
+        message_len = Util.zeros(1)
+        message = Util.zeros(ciphertext.bytesize - tag_bytes)
+
+        success = do_decrypt(message, message_len, nonce, ciphertext, additional_data)
+        raise CryptoError, "Decryption failed. Ciphertext failed verification." unless success
+        message
+      end
+
+      # The crypto primitive for this aead instance
+      #
+      # @return [Symbol] The primitive used
+      def primitive
+        self.class.primitive
+      end
+
+      # The nonce bytes for the AEAD class
+      #
+      # @return [Integer] The number of bytes in a valid nonce
+      def self.nonce_bytes
+        self::NPUBBYTES
+      end
+
+      # The nonce bytes for the AEAD instance
+      #
+      # @return [Integer] The number of bytes in a valid nonce
+      def nonce_bytes
+        self.class.nonce_bytes
+      end
+
+      # The key bytes for the AEAD class
+      #
+      # @return [Integer] The number of bytes in a valid key
+      def self.key_bytes
+        self::KEYBYTES
+      end
+
+      # The key bytes for the AEAD instance
+      #
+      # @return [Integer] The number of bytes in a valid key
+      def key_bytes
+        self.class.key_bytes
+      end
+
+      # The number bytes in the tag or authenticator from this AEAD class
+      #
+      # @return [Integer] number of tag bytes
+      def self.tag_bytes
+        self::ABYTES
+      end
+
+      # The number of bytes in the tag or authenticator for this AEAD instance
+      #
+      # @return [Integer] number of tag bytes
+      def tag_bytes
+        self.class.tag_bytes
+      end
+
+      private
+
+      def do_encrypt(_ciphertext, _ciphertext_len, _nonce, _message, _additional_data)
+        raise NotImplementedError
+      end
+
+      def do_decrypt(_message, _message_len, _nonce, _ciphertext, _additional_data)
+        raise NotImplementedError
+      end
+    end
+  end
+end

--- a/lib/rbnacl/aead/aead.rb
+++ b/lib/rbnacl/aead/aead.rb
@@ -45,7 +45,7 @@ module RbNaCl
         Util.check_length(nonce, nonce_bytes, "Nonce")
 
         ciphertext_len = Util.zeros(1)
-        ciphertext = Util.zeros(message.bytesize + tag_bytes)
+        ciphertext = Util.zeros(data_len(message) + tag_bytes)
 
         success = do_encrypt(ciphertext, ciphertext_len, nonce, message, additional_data)
         raise CryptoError, "Encryption failed" unless success
@@ -66,7 +66,7 @@ module RbNaCl
         Util.check_length(nonce, nonce_bytes, "Nonce")
 
         message_len = Util.zeros(1)
-        message = Util.zeros(ciphertext.bytesize - tag_bytes)
+        message = Util.zeros(data_len(ciphertext) - tag_bytes)
 
         success = do_decrypt(message, message_len, nonce, ciphertext, additional_data)
         raise CryptoError, "Decryption failed. Ciphertext failed verification." unless success
@@ -123,6 +123,11 @@ module RbNaCl
       end
 
       private
+
+      def data_len(data)
+        return 0 if data.nil?
+        data.bytesize
+      end
 
       def do_encrypt(_ciphertext, _ciphertext_len, _nonce, _message, _additional_data)
         raise NotImplementedError

--- a/lib/rbnacl/aead/chacha20poly1305.rb
+++ b/lib/rbnacl/aead/chacha20poly1305.rb
@@ -19,34 +19,64 @@ module RbNaCl
                       [:pointer, :pointer, :pointer, :pointer, :ulong_long, :pointer, :ulong_long, :pointer, :pointer]
 
 
+      # Create a new AEAD using the original chacha20poly1305 construction
+      #
+      # Sets up the AEAD with a secret key for encrypting and decrypting messages.
+      #
+      # @param key [String] The key to encrypt and decrypt with
+      #
+      # @raise [RbNaCl::LengthError] on invalid keys
+      #
+      # @return [RbNaCl::AEAD::Chacha20Poly1305IETF] The new AEAD Box, ready to use
+      def initialize(key)
+        @key = Util.check_string(key, KEYBYTES, "Secret key")
+      end
+
+
       # Encrypts and authenticates a message with additional data
-      def encrypt(key, nonce, message, additional_data)
+      #
+      # @param nonce [String] An 8-byte string containing the nonce.
+      # @param message [String] The message to be encrypted.
+      # @param additional_data [String] The additional authenticated data
+      #
+      # @raise [RbNaCl::LengthError] If the nonce is not valid
+      # @raise [RbNaCl::CryptoError] If the ciphertext cannot be authenticated.
+      #
+      # @return [String] The decrypted message (BINARY encoded)
+      def encrypt(nonce, message, additional_data)
+        Util.check_length(nonce, NPUBBYTES, "Nonce")
+
         ciphertext_len = Util.zeros(1)
         ciphertext = Util.zeros(message.bytesize + ABYTES)
-
-        Util.check_length(nonce, NPUBBYTES, "Nonce")
-        key = Util.check_string(key, KEYBYTES, "Secret key")
 
         success = self.class.aead_chacha20poly1305_encrypt(ciphertext, ciphertext_len,
                                                            message, message.bytesize,
                                                            additional_data, additional_data.bytesize,
-                                                           nil, nonce, key)
+                                                           nil, nonce, @key)
         raise CryptoError, "Encryption failed" unless success
         ciphertext
       end
 
       # Decrypts and verifies an encrypted message with additional data
-      def decrypt(key, nonce, ciphertext, additional_data)
+      #
+      # @param nonce [String] An 8-byte string containing the nonce.
+      # @param ciphertext [String] The message to be decrypted.
+      # @param additional_data [String] The additional authenticated data
+      #
+      # @raise [RbNaCl::LengthError] If the nonce is not valid
+      # @raise [RbNaCl::CryptoError] If the ciphertext cannot be authenticated.
+      #
+      # @return [String] The decrypted message (BINARY encoded)
+      def decrypt(nonce, ciphertext, additional_data)
+        Util.check_length(nonce, NPUBBYTES, "Nonce")
+
         message_len = Util.zeros(1)
         message = Util.zeros(ciphertext.bytesize - ABYTES)
-
-        Util.check_length(nonce, NPUBBYTES, "Nonce")
-        key = Util.check_string(key, KEYBYTES, "Secret key")
 
         success = self.class.aead_chacha20poly1305_decrypt(message, message_len, nil,
                                                            ciphertext, ciphertext.bytesize,
                                                            additional_data, additional_data.bytesize,
-                                                           nonce, key)
+                                                           nonce, @key)
         raise CryptoError, "Decryption failed. Ciphertext failed verification." unless success
         message
       end

--- a/lib/rbnacl/aead/chacha20poly1305.rb
+++ b/lib/rbnacl/aead/chacha20poly1305.rb
@@ -80,6 +80,27 @@ module RbNaCl
         raise CryptoError, "Decryption failed. Ciphertext failed verification." unless success
         message
       end
+
+      # The nonce bytes for the AEAD class
+      #
+      # @return [Integer] The number of bytes in a valid nonce
+      def self.nonce_bytes
+        NPUBBYTES
+      end
+
+      # The nonce bytes for the AEAD instance
+      #
+      # @return [Integer] The number of bytes in a valid nonce
+      def nonce_bytes
+        NPUBBYTES
+      end
+
+      # The key bytes for the AEAD class
+      #
+      # @return [Integer] The number of bytes in a valid key
+      def self.key_bytes
+        KEYBYTES
+      end
     end
   end
 end

--- a/lib/rbnacl/aead/chacha20poly1305.rb
+++ b/lib/rbnacl/aead/chacha20poly1305.rb
@@ -24,15 +24,15 @@ module RbNaCl
 
       def do_encrypt(ciphertext, ciphertext_len, nonce, message, additional_data)
         self.class.aead_chacha20poly1305_encrypt(ciphertext, ciphertext_len,
-                                                 message, message.bytesize,
-                                                 additional_data, additional_data.bytesize,
+                                                 message, data_len(message),
+                                                 additional_data, data_len(additional_data),
                                                  nil, nonce, @key)
       end
 
       def do_decrypt(message, message_len, nonce, ciphertext, additional_data)
         self.class.aead_chacha20poly1305_decrypt(message, message_len, nil,
-                                                 ciphertext, ciphertext.bytesize,
-                                                 additional_data, additional_data.bytesize,
+                                                 ciphertext, data_len(ciphertext),
+                                                 additional_data, data_len(additional_data),
                                                  nonce, @key)
       end
     end

--- a/lib/rbnacl/aead/chacha20poly1305.rb
+++ b/lib/rbnacl/aead/chacha20poly1305.rb
@@ -1,6 +1,8 @@
 # encoding: binary
 module RbNaCl
   module AEAD
+    # This class contains wrappers for the original libsodium implementation of
+    # Authenticated Encryption with Additional Data using ChaCha20-Poly1305
     class Chacha20Poly1305
       extend Sodium
 
@@ -18,7 +20,6 @@ module RbNaCl
                       :crypto_aead_chacha20poly1305_decrypt,
                       [:pointer, :pointer, :pointer, :pointer, :ulong_long, :pointer, :ulong_long, :pointer, :pointer]
 
-
       # Create a new AEAD using the original chacha20poly1305 construction
       #
       # Sets up the AEAD with a secret key for encrypting and decrypting messages.
@@ -32,8 +33,7 @@ module RbNaCl
         @key = Util.check_string(key, KEYBYTES, "Secret key")
       end
 
-
-      # Encrypts and authenticates a message with additional data
+      # Encrypts and authenticates a message with additional authenticated data
       #
       # @param nonce [String] An 8-byte string containing the nonce.
       # @param message [String] The message to be encrypted.
@@ -57,7 +57,7 @@ module RbNaCl
         ciphertext
       end
 
-      # Decrypts and verifies an encrypted message with additional data
+      # Decrypts and verifies an encrypted message with additional authenticated data
       #
       # @param nonce [String] An 8-byte string containing the nonce.
       # @param ciphertext [String] The message to be decrypted.

--- a/lib/rbnacl/aead/chacha20poly1305.rb
+++ b/lib/rbnacl/aead/chacha20poly1305.rb
@@ -1,0 +1,57 @@
+# encoding: binary
+module RbNaCl
+  module AEAD
+    class Chacha20Poly1305
+      extend Sodium
+
+      sodium_type :aead
+      sodium_primitive :chacha20poly1305
+      sodium_constant :KEYBYTES
+      sodium_constant :NPUBBYTES
+      sodium_constant :ABYTES
+
+      sodium_function :aead_chacha20poly1305_encrypt,
+                      :crypto_aead_chacha20poly1305_encrypt,
+                      [:pointer, :pointer, :pointer, :ulong_long, :pointer, :ulong_long, :pointer, :pointer, :pointer]
+
+      sodium_function :aead_chacha20poly1305_decrypt,
+                      :crypto_aead_chacha20poly1305_decrypt,
+                      [:pointer, :pointer, :pointer, :pointer, :ulong_long, :pointer, :ulong_long, :pointer, :pointer]
+
+
+      # Encrypts and authenticates a message with additional data
+      def encrypt(key, nonce, message, additional_data)
+        ciphertext_len = Util.zeros(1)
+        ciphertext = Util.zeros(message.bytesize + ABYTES)
+
+        Util.check_length(nonce, nonce_bytes, "Nonce")
+        key = Util.check_string(key, KEYBYTES, "Secret key")
+
+        success = self.class.aead_chacha20poly1305_encrypt(ciphertext, ciphertext_len,
+                                                           message, message.bytesize,
+                                                           additional_data, additional_data.bytesize,
+                                                           nil, nonce, key)
+        raise CryptoError, "Encryption failed" unless success
+
+        ciphertext
+      end
+
+      def decrypt(key, nonce, ciphertext, additional_data)
+        message_len = Util.zeros(1)
+        message = Util.zeros(ciphertext.bytesize - ABYTES)
+
+        Util.check_length(nonce, nonce_bytes, "Nonce")
+        key = Util.check_string(key, KEYBYTES, "Secret key")
+
+        success = self.class.aead_chacha20poly1305_encrypt(message, message_len
+                                                           ciphertext, ciphertext_len,
+                                                           message, message.bytesize,
+                                                           additional_data, additional_data.bytesize,
+                                                           nil, nonce, key)
+        raise CryptoError, "Decryption failed. Ciphertext failed verification." unless success
+
+        message
+      end
+    end
+  end
+end

--- a/lib/rbnacl/aead/chacha20poly1305_ietf.rb
+++ b/lib/rbnacl/aead/chacha20poly1305_ietf.rb
@@ -3,7 +3,7 @@ module RbNaCl
   module AEAD
     # This class contains wrappers for the IETF implementation of
     # Authenticated Encryption with Additional Data using ChaCha20-Poly1305
-    class Chacha20Poly1305IETF
+    class Chacha20Poly1305IETF < GenericAEAD
       extend Sodium
 
       sodium_type :aead
@@ -20,86 +20,20 @@ module RbNaCl
                       :crypto_aead_chacha20poly1305_ietf_decrypt,
                       [:pointer, :pointer, :pointer, :pointer, :ulong_long, :pointer, :ulong_long, :pointer, :pointer]
 
-      # Create a new AEAD using the IETF chacha20poly1305 construction
-      #
-      # Sets up AEAD with a secret key for encrypting and decrypting messages.
-      #
-      # @param key [String] The key to encrypt and decrypt with
-      #
-      # @raise [RbNaCl::LengthError] on invalid keys
-      #
-      # @return [RbNaCl::AEAD::Chacha20Poly1305IETF] The new AEAD box, ready to use
-      def initialize(key)
-        @key = Util.check_string(key, KEYBYTES, "Secret key")
+      private
+
+      def do_encrypt(ciphertext, ciphertext_len, nonce, message, additional_data)
+        self.class.aead_chacha20poly1305_ietf_encrypt(ciphertext, ciphertext_len,
+                                                      message, message.bytesize,
+                                                      additional_data, additional_data.bytesize,
+                                                      nil, nonce, @key)
       end
 
-      # Encrypts and authenticates a message with additional data
-      #
-      # @param nonce [String] A 12-byte string containing the nonce.
-      # @param message [String] The message to be encrypted.
-      # @param additional_data [String] The additional authenticated data
-      #
-      # @raise [RbNaCl::LengthError] If the nonce is not valid
-      # @raise [RbNaCl::CryptoError] If the ciphertext cannot be authenticated.
-      #
-      # @return [String] The decrypted message (BINARY encoded)
-      def encrypt(nonce, message, additional_data)
-        Util.check_length(nonce, NPUBBYTES, "Nonce")
-
-        ciphertext_len = Util.zeros(1)
-        ciphertext = Util.zeros(message.bytesize + ABYTES)
-
-        success = self.class.aead_chacha20poly1305_ietf_encrypt(ciphertext, ciphertext_len,
-                                                                message, message.bytesize,
-                                                                additional_data, additional_data.bytesize,
-                                                                nil, nonce, @key)
-        raise CryptoError, "Encryption failed" unless success
-        ciphertext
-      end
-
-      # Decrypts and verifies an encrypted message with additional data
-      #
-      # @param nonce [String] A 12-byte string containing the nonce.
-      # @param ciphertext [String] The message to be decrypted.
-      # @param additional_data [String] The additional authenticated data
-      #
-      # @raise [RbNaCl::LengthError] If the nonce is not valid
-      # @raise [RbNaCl::CryptoError] If the ciphertext cannot be authenticated.
-      #
-      # @return [String] The decrypted message (BINARY encoded)
-      def decrypt(nonce, ciphertext, additional_data)
-        Util.check_length(nonce, NPUBBYTES, "Nonce")
-
-        message_len = Util.zeros(1)
-        message = Util.zeros(ciphertext.bytesize - ABYTES)
-
-        success = self.class.aead_chacha20poly1305_ietf_decrypt(message, message_len, nil,
-                                                                ciphertext, ciphertext.bytesize,
-                                                                additional_data, additional_data.bytesize,
-                                                                nonce, @key)
-        raise CryptoError, "Decryption failed. Ciphertext failed verification." unless success
-        message
-      end
-
-      # The nonce bytes for the AEAD class
-      #
-      # @return [Integer] The number of bytes in a valid nonce
-      def self.nonce_bytes
-        NPUBBYTES
-      end
-
-      # The nonce bytes for the AEAD instance
-      #
-      # @return [Integer] The number of bytes in a valid nonce
-      def nonce_bytes
-        NPUBBYTES
-      end
-
-      # The key bytes for the AEAD class
-      #
-      # @return [Integer] The number of bytes in a valid key
-      def self.key_bytes
-        KEYBYTES
+      def do_decrypt(message, message_len, nonce, ciphertext, additional_data)
+        self.class.aead_chacha20poly1305_ietf_decrypt(message, message_len, nil,
+                                                      ciphertext, ciphertext.bytesize,
+                                                      additional_data, additional_data.bytesize,
+                                                      nonce, @key)
       end
     end
   end

--- a/lib/rbnacl/aead/chacha20poly1305_ietf.rb
+++ b/lib/rbnacl/aead/chacha20poly1305_ietf.rb
@@ -5,35 +5,37 @@ module RbNaCl
     # Authenticated Encryption with Additional Data using ChaCha20-Poly1305
     class Chacha20Poly1305IETF < GenericAEAD
       extend Sodium
+      if Sodium::Version.supported_version?("1.0.9")
+        sodium_type :aead
+        sodium_primitive :chacha20poly1305_ietf
 
-      sodium_type :aead
-      sodium_primitive :chacha20poly1305_ietf
-      sodium_constant :KEYBYTES
-      sodium_constant :NPUBBYTES
-      sodium_constant :ABYTES
+        sodium_constant :KEYBYTES
+        sodium_constant :NPUBBYTES
+        sodium_constant :ABYTES
 
-      sodium_function :aead_chacha20poly1305_ietf_encrypt,
-                      :crypto_aead_chacha20poly1305_ietf_encrypt,
-                      [:pointer, :pointer, :pointer, :ulong_long, :pointer, :ulong_long, :pointer, :pointer, :pointer]
+        sodium_function :aead_chacha20poly1305_ietf_encrypt,
+                        :crypto_aead_chacha20poly1305_ietf_encrypt,
+                        [:pointer, :pointer, :pointer, :ulong_long, :pointer, :ulong_long, :pointer, :pointer, :pointer]
 
-      sodium_function :aead_chacha20poly1305_ietf_decrypt,
-                      :crypto_aead_chacha20poly1305_ietf_decrypt,
-                      [:pointer, :pointer, :pointer, :pointer, :ulong_long, :pointer, :ulong_long, :pointer, :pointer]
+        sodium_function :aead_chacha20poly1305_ietf_decrypt,
+                        :crypto_aead_chacha20poly1305_ietf_decrypt,
+                        [:pointer, :pointer, :pointer, :pointer, :ulong_long, :pointer, :ulong_long, :pointer, :pointer]
 
-      private
+        private
 
-      def do_encrypt(ciphertext, ciphertext_len, nonce, message, additional_data)
-        self.class.aead_chacha20poly1305_ietf_encrypt(ciphertext, ciphertext_len,
-                                                      message, message.bytesize,
-                                                      additional_data, additional_data.bytesize,
-                                                      nil, nonce, @key)
-      end
+        def do_encrypt(ciphertext, ciphertext_len, nonce, message, additional_data)
+          self.class.aead_chacha20poly1305_ietf_encrypt(ciphertext, ciphertext_len,
+                                                        message, message.bytesize,
+                                                        additional_data, additional_data.bytesize,
+                                                        nil, nonce, @key)
+        end
 
-      def do_decrypt(message, message_len, nonce, ciphertext, additional_data)
-        self.class.aead_chacha20poly1305_ietf_decrypt(message, message_len, nil,
-                                                      ciphertext, ciphertext.bytesize,
-                                                      additional_data, additional_data.bytesize,
-                                                      nonce, @key)
+        def do_decrypt(message, message_len, nonce, ciphertext, additional_data)
+          self.class.aead_chacha20poly1305_ietf_decrypt(message, message_len, nil,
+                                                        ciphertext, ciphertext.bytesize,
+                                                        additional_data, additional_data.bytesize,
+                                                        nonce, @key)
+        end
       end
     end
   end

--- a/lib/rbnacl/aead/chacha20poly1305_ietf.rb
+++ b/lib/rbnacl/aead/chacha20poly1305_ietf.rb
@@ -25,15 +25,15 @@ module RbNaCl
 
         def do_encrypt(ciphertext, ciphertext_len, nonce, message, additional_data)
           self.class.aead_chacha20poly1305_ietf_encrypt(ciphertext, ciphertext_len,
-                                                        message, message.bytesize,
-                                                        additional_data, additional_data.bytesize,
+                                                        message, data_len(message),
+                                                        additional_data, data_len(additional_data),
                                                         nil, nonce, @key)
         end
 
         def do_decrypt(message, message_len, nonce, ciphertext, additional_data)
           self.class.aead_chacha20poly1305_ietf_decrypt(message, message_len, nil,
-                                                        ciphertext, ciphertext.bytesize,
-                                                        additional_data, additional_data.bytesize,
+                                                        ciphertext, data_len(ciphertext),
+                                                        additional_data, data_len(additional_data),
                                                         nonce, @key)
         end
       end

--- a/lib/rbnacl/aead/chacha20poly1305_ietf.rb
+++ b/lib/rbnacl/aead/chacha20poly1305_ietf.rb
@@ -1,21 +1,21 @@
 # encoding: binary
 module RbNaCl
   module AEAD
-    class Chacha20Poly1305
+    class Chacha20Poly1305IETF
       extend Sodium
 
       sodium_type :aead
-      sodium_primitive :chacha20poly1305
+      sodium_primitive :chacha20poly1305_ietf
       sodium_constant :KEYBYTES
       sodium_constant :NPUBBYTES
       sodium_constant :ABYTES
 
-      sodium_function :aead_chacha20poly1305_encrypt,
-                      :crypto_aead_chacha20poly1305_encrypt,
+      sodium_function :aead_chacha20poly1305_ietf_encrypt,
+                      :crypto_aead_chacha20poly1305_ietf_encrypt,
                       [:pointer, :pointer, :pointer, :ulong_long, :pointer, :ulong_long, :pointer, :pointer, :pointer]
 
-      sodium_function :aead_chacha20poly1305_decrypt,
-                      :crypto_aead_chacha20poly1305_decrypt,
+      sodium_function :aead_chacha20poly1305_ietf_decrypt,
+                      :crypto_aead_chacha20poly1305_ietf_decrypt,
                       [:pointer, :pointer, :pointer, :pointer, :ulong_long, :pointer, :ulong_long, :pointer, :pointer]
 
 
@@ -27,7 +27,7 @@ module RbNaCl
         Util.check_length(nonce, NPUBBYTES, "Nonce")
         key = Util.check_string(key, KEYBYTES, "Secret key")
 
-        success = self.class.aead_chacha20poly1305_encrypt(ciphertext, ciphertext_len,
+        success = self.class.aead_chacha20poly1305_ietf_encrypt(ciphertext, ciphertext_len,
                                                            message, message.bytesize,
                                                            additional_data, additional_data.bytesize,
                                                            nil, nonce, key)
@@ -43,7 +43,7 @@ module RbNaCl
         Util.check_length(nonce, NPUBBYTES, "Nonce")
         key = Util.check_string(key, KEYBYTES, "Secret key")
 
-        success = self.class.aead_chacha20poly1305_decrypt(message, message_len, nil,
+        success = self.class.aead_chacha20poly1305_ietf_decrypt(message, message_len, nil,
                                                            ciphertext, ciphertext.bytesize,
                                                            additional_data, additional_data.bytesize,
                                                            nonce, key)

--- a/lib/rbnacl/aead/chacha20poly1305_ietf.rb
+++ b/lib/rbnacl/aead/chacha20poly1305_ietf.rb
@@ -79,6 +79,27 @@ module RbNaCl
         raise CryptoError, "Decryption failed. Ciphertext failed verification." unless success
         message
       end
+
+      # The nonce bytes for the AEAD class
+      #
+      # @return [Integer] The number of bytes in a valid nonce
+      def self.nonce_bytes
+        NPUBBYTES
+      end
+
+      # The nonce bytes for the AEAD instance
+      #
+      # @return [Integer] The number of bytes in a valid nonce
+      def nonce_bytes
+        NPUBBYTES
+      end
+
+      # The key bytes for the AEAD class
+      #
+      # @return [Integer] The number of bytes in a valid key
+      def self.key_bytes
+        KEYBYTES
+      end
     end
   end
 end

--- a/lib/rbnacl/aead/chacha20poly1305_ietf.rb
+++ b/lib/rbnacl/aead/chacha20poly1305_ietf.rb
@@ -1,6 +1,8 @@
 # encoding: binary
 module RbNaCl
   module AEAD
+    # This class contains wrappers for the IETF implementation of
+    # Authenticated Encryption with Additional Data using ChaCha20-Poly1305
     class Chacha20Poly1305IETF
       extend Sodium
 
@@ -17,7 +19,6 @@ module RbNaCl
       sodium_function :aead_chacha20poly1305_ietf_decrypt,
                       :crypto_aead_chacha20poly1305_ietf_decrypt,
                       [:pointer, :pointer, :pointer, :pointer, :ulong_long, :pointer, :ulong_long, :pointer, :pointer]
-
 
       # Create a new AEAD using the IETF chacha20poly1305 construction
       #
@@ -49,9 +50,9 @@ module RbNaCl
         ciphertext = Util.zeros(message.bytesize + ABYTES)
 
         success = self.class.aead_chacha20poly1305_ietf_encrypt(ciphertext, ciphertext_len,
-                                                           message, message.bytesize,
-                                                           additional_data, additional_data.bytesize,
-                                                           nil, nonce, @key)
+                                                                message, message.bytesize,
+                                                                additional_data, additional_data.bytesize,
+                                                                nil, nonce, @key)
         raise CryptoError, "Encryption failed" unless success
         ciphertext
       end
@@ -73,9 +74,9 @@ module RbNaCl
         message = Util.zeros(ciphertext.bytesize - ABYTES)
 
         success = self.class.aead_chacha20poly1305_ietf_decrypt(message, message_len, nil,
-                                                           ciphertext, ciphertext.bytesize,
-                                                           additional_data, additional_data.bytesize,
-                                                           nonce, @key)
+                                                                ciphertext, ciphertext.bytesize,
+                                                                additional_data, additional_data.bytesize,
+                                                                nonce, @key)
         raise CryptoError, "Decryption failed. Ciphertext failed verification." unless success
         message
       end

--- a/lib/rbnacl/aead/chacha20poly1305_ietf.rb
+++ b/lib/rbnacl/aead/chacha20poly1305_ietf.rb
@@ -19,34 +19,63 @@ module RbNaCl
                       [:pointer, :pointer, :pointer, :pointer, :ulong_long, :pointer, :ulong_long, :pointer, :pointer]
 
 
+      # Create a new AEAD using the IETF chacha20poly1305 construction
+      #
+      # Sets up AEAD with a secret key for encrypting and decrypting messages.
+      #
+      # @param key [String] The key to encrypt and decrypt with
+      #
+      # @raise [RbNaCl::LengthError] on invalid keys
+      #
+      # @return [RbNaCl::AEAD::Chacha20Poly1305IETF] The new AEAD box, ready to use
+      def initialize(key)
+        @key = Util.check_string(key, KEYBYTES, "Secret key")
+      end
+
       # Encrypts and authenticates a message with additional data
-      def encrypt(key, nonce, message, additional_data)
+      #
+      # @param nonce [String] A 12-byte string containing the nonce.
+      # @param message [String] The message to be encrypted.
+      # @param additional_data [String] The additional authenticated data
+      #
+      # @raise [RbNaCl::LengthError] If the nonce is not valid
+      # @raise [RbNaCl::CryptoError] If the ciphertext cannot be authenticated.
+      #
+      # @return [String] The decrypted message (BINARY encoded)
+      def encrypt(nonce, message, additional_data)
+        Util.check_length(nonce, NPUBBYTES, "Nonce")
+
         ciphertext_len = Util.zeros(1)
         ciphertext = Util.zeros(message.bytesize + ABYTES)
-
-        Util.check_length(nonce, NPUBBYTES, "Nonce")
-        key = Util.check_string(key, KEYBYTES, "Secret key")
 
         success = self.class.aead_chacha20poly1305_ietf_encrypt(ciphertext, ciphertext_len,
                                                            message, message.bytesize,
                                                            additional_data, additional_data.bytesize,
-                                                           nil, nonce, key)
+                                                           nil, nonce, @key)
         raise CryptoError, "Encryption failed" unless success
         ciphertext
       end
 
       # Decrypts and verifies an encrypted message with additional data
-      def decrypt(key, nonce, ciphertext, additional_data)
+      #
+      # @param nonce [String] A 12-byte string containing the nonce.
+      # @param ciphertext [String] The message to be decrypted.
+      # @param additional_data [String] The additional authenticated data
+      #
+      # @raise [RbNaCl::LengthError] If the nonce is not valid
+      # @raise [RbNaCl::CryptoError] If the ciphertext cannot be authenticated.
+      #
+      # @return [String] The decrypted message (BINARY encoded)
+      def decrypt(nonce, ciphertext, additional_data)
+        Util.check_length(nonce, NPUBBYTES, "Nonce")
+
         message_len = Util.zeros(1)
         message = Util.zeros(ciphertext.bytesize - ABYTES)
-
-        Util.check_length(nonce, NPUBBYTES, "Nonce")
-        key = Util.check_string(key, KEYBYTES, "Secret key")
 
         success = self.class.aead_chacha20poly1305_ietf_decrypt(message, message_len, nil,
                                                            ciphertext, ciphertext.bytesize,
                                                            additional_data, additional_data.bytesize,
-                                                           nonce, key)
+                                                           nonce, @key)
         raise CryptoError, "Decryption failed. Ciphertext failed verification." unless success
         message
       end

--- a/lib/rbnacl/sodium/version.rb
+++ b/lib/rbnacl/sodium/version.rb
@@ -17,7 +17,7 @@ module RbNaCl
 
       # Determine if a given feature is supported based on Sodium version
       def self.supported_version?(version)
-        sodium_version_string >= version
+        sodium_version_string <= version
       end
 
       case installed_version <=> minimum_version

--- a/lib/rbnacl/sodium/version.rb
+++ b/lib/rbnacl/sodium/version.rb
@@ -15,6 +15,11 @@ module RbNaCl
       installed_version = [MAJOR, MINOR, PATCH]
       minimum_version   = MINIMUM_LIBSODIUM_VERSION.split(".").map(&:to_i)
 
+      # Determine if a given feature is supported based on Sodium version
+      def self.supported_version?(version)
+        sodium_version_string >= version
+      end
+
       case installed_version <=> minimum_version
       when -1
         raise "Sorry, you need to install libsodium #{MINIMUM_LIBSODIUM_VERSION}+. You have #{Version::STRING} installed"

--- a/lib/rbnacl/sodium/version.rb
+++ b/lib/rbnacl/sodium/version.rb
@@ -17,7 +17,7 @@ module RbNaCl
 
       # Determine if a given feature is supported based on Sodium version
       def self.supported_version?(version)
-        sodium_version_string <= version
+        Gem::Version.new(sodium_version_string) >= Gem::Version.new(version)
       end
 
       case installed_version <=> minimum_version

--- a/lib/rbnacl/test_vectors.rb
+++ b/lib/rbnacl/test_vectors.rb
@@ -1,4 +1,5 @@
 # encoding: binary
+# rubocop:disable ModuleLength
 
 # NaCl/libsodium for Ruby
 module RbNaCl

--- a/lib/rbnacl/test_vectors.rb
+++ b/lib/rbnacl/test_vectors.rb
@@ -154,7 +154,7 @@ module RbNaCl
                                                 "637265656e20776f756c642062652069742e",
     aead_chacha20poly1305_ietf_nonce:           "070000004041424344454647",
     aead_chacha20poly1305_ietf_ad:              "50515253c0c1c2c3c4c5c6c7",
-    aead_chacha20poly1305_orig_ciphertext:      "d31a8d34648e60db7b86afbc53ef7ec2a4aded51296e08fea9e2b5a736ee62d6" \
+    aead_chacha20poly1305_ietf_ciphertext:      "d31a8d34648e60db7b86afbc53ef7ec2a4aded51296e08fea9e2b5a736ee62d6" \
                                                 "3dbea45e8ca9671282fafb69da92728b1a71de0a9e060b2905d6a5b67ecd3b36" \
                                                 "92ddbd7f2d778b8c9803aee328091b58fab324e4fad675945585808b4831d7bc" \
                                                 "3ff4def08e4b7a9de576d26586cec64b61161ae10b594f09e26a7e902ecbd060" \

--- a/lib/rbnacl/test_vectors.rb
+++ b/lib/rbnacl/test_vectors.rb
@@ -135,6 +135,29 @@ module RbNaCl
     auth_hmacsha256:    "7f7b9b707e8790ca8620ff94df5e6533ddc8e994060ce310c9d7de04d44aabc3",
     auth_hmacsha512256: "b2a31b8d4e01afcab2ee545b5caf4e3d212a99d7b3a116a97cec8e83c32e107d",
     auth_hmacsha512:    "b2a31b8d4e01afcab2ee545b5caf4e3d212a99d7b3a116a97cec8e83c32e107d" \
-                        "270e3921f69016c267a63ab4b226449a0dee0dc7dcb897a9bce9d27d788f8e8d"
+                        "270e3921f69016c267a63ab4b226449a0dee0dc7dcb897a9bce9d27d788f8e8d",
+
+    # AEAD ChaCha20-Poly1305 original implementation test vectors
+    # Taken from https://tools.ietf.org/html/draft-agl-tls-chacha20poly1305-04
+    aead_chacha20poly1305_orig_key:             "4290bcb154173531f314af57f3be3b5006da371ece272afa1b5dbdd1100a1007",
+    aead_chacha20poly1305_orig_message:         "86d09974840bded2a5ca",
+    aead_chacha20poly1305_orig_nonce:           "cd7cf67be39c794a",
+    aead_chacha20poly1305_orig_ad:              "87e229d4500845a079c0",
+    aead_chacha20poly1305_orig_ciphertext:      "e3e446f7ede9a19b62a4677dabf4e3d24b876bb284753896e1d6",
+
+    # AEAD ChaCha20-Poly1305 IETF test vectors
+    # Taken from https://tools.ietf.org/html/rfc7539
+    aead_chacha20poly1305_ietf_key:             "808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f",
+    aead_chacha20poly1305_ietf_message:         "4c616469657320616e642047656e746c656d656e206f662074686520636c6173" \
+                                                "73206f66202739393a204966204920636f756c64206f6666657220796f75206f" \
+                                                "6e6c79206f6e652074697020666f7220746865206675747572652c2073756e73" \
+                                                "637265656e20776f756c642062652069742e",
+    aead_chacha20poly1305_ietf_nonce:           "070000004041424344454647",
+    aead_chacha20poly1305_ietf_ad:              "50515253c0c1c2c3c4c5c6c7",
+    aead_chacha20poly1305_orig_ciphertext:      "d31a8d34648e60db7b86afbc53ef7ec2a4aded51296e08fea9e2b5a736ee62d6" \
+                                                "3dbea45e8ca9671282fafb69da92728b1a71de0a9e060b2905d6a5b67ecd3b36" \
+                                                "92ddbd7f2d778b8c9803aee328091b58fab324e4fad675945585808b4831d7bc" \
+                                                "3ff4def08e4b7a9de576d26586cec64b61161ae10b594f09e26a7e902ecbd060" \
+                                                "0691"
   }.freeze
 end

--- a/spec/rbnacl/aead/chacha20poly1305_ietf_spec.rb
+++ b/spec/rbnacl/aead/chacha20poly1305_ietf_spec.rb
@@ -1,0 +1,14 @@
+# encoding: binary
+require "spec_helper"
+
+RSpec.describe RbNaCl::AEAD::Chacha20Poly1305IETF do
+  include_examples "aead" do
+    let(:key) {vector :aead_chacha20poly1305_ietf_key}
+    let(:message) {vector :aead_chacha20poly1305_ietf_message}
+    let(:nonce) {vector :aead_chacha20poly1305_ietf_nonce}
+    let(:ad) {vector :aead_chacha20poly1305_ietf_ad}
+    let(:ciphertext) {vector :aead_chacha20poly1305_ietf_ciphertext}
+
+    let(:aead) { RbNaCl::AEAD::Chacha20Poly1305IETF.new(key) }
+  end
+end

--- a/spec/rbnacl/aead/chacha20poly1305_ietf_spec.rb
+++ b/spec/rbnacl/aead/chacha20poly1305_ietf_spec.rb
@@ -2,13 +2,15 @@
 require "spec_helper"
 
 RSpec.describe RbNaCl::AEAD::Chacha20Poly1305IETF do
-  include_examples "aead" do
-    let(:key) {vector :aead_chacha20poly1305_ietf_key}
-    let(:message) {vector :aead_chacha20poly1305_ietf_message}
-    let(:nonce) {vector :aead_chacha20poly1305_ietf_nonce}
-    let(:ad) {vector :aead_chacha20poly1305_ietf_ad}
-    let(:ciphertext) {vector :aead_chacha20poly1305_ietf_ciphertext}
+  if RbNaCl::Sodium::Version.supported_version?("1.0.9")
+    include_examples "aead" do
+      let(:key) {vector :aead_chacha20poly1305_ietf_key}
+      let(:message) {vector :aead_chacha20poly1305_ietf_message}
+      let(:nonce) {vector :aead_chacha20poly1305_ietf_nonce}
+      let(:ad) {vector :aead_chacha20poly1305_ietf_ad}
+      let(:ciphertext) {vector :aead_chacha20poly1305_ietf_ciphertext}
 
-    let(:aead) { RbNaCl::AEAD::Chacha20Poly1305IETF.new(key) }
+      let(:aead) { RbNaCl::AEAD::Chacha20Poly1305IETF.new(key) }
+    end
   end
 end

--- a/spec/rbnacl/aead/chacha20poly1305_orig_spec.rb
+++ b/spec/rbnacl/aead/chacha20poly1305_orig_spec.rb
@@ -1,0 +1,14 @@
+# encoding: binary
+require "spec_helper"
+
+RSpec.describe RbNaCl::AEAD::Chacha20Poly1305 do
+  include_examples "aead" do
+    let(:key) {vector :aead_chacha20poly1305_orig_key}
+    let(:message) {vector :aead_chacha20poly1305_orig_message}
+    let(:nonce) {vector :aead_chacha20poly1305_orig_nonce}
+    let(:ad) {vector :aead_chacha20poly1305_orig_ad}
+    let(:ciphertext) {vector :aead_chacha20poly1305_orig_ciphertext}
+
+    let(:aead) { RbNaCl::AEAD::Chacha20Poly1305.new(key) }
+  end
+end

--- a/spec/rbnacl/aead/chacha20poly1305_spec.rb
+++ b/spec/rbnacl/aead/chacha20poly1305_spec.rb
@@ -1,0 +1,82 @@
+# encoding: binary
+require "spec_helper"
+
+RSpec.describe RbNaCl::AEAD::Chacha20Poly1305 do
+  let(:key) {vector :aead_chacha20poly1305_orig_key}
+  let(:message) {vector :aead_chacha20poly1305_orig_message}
+  let(:nonce) {vector :aead_chacha20poly1305_orig_nonce}
+  let(:ad) {vector :aead_chacha20poly1305_orig_ad}
+  let(:ciphertext) {vector :aead_chacha20poly1305_orig_ciphertext}
+
+  let(:aead) { RbNaCl::AEAD::Chacha20Poly1305.new(key) }
+
+  let(:corrupt_ciphertext) { ciphertext.succ}
+  let(:trunc_ciphertext) { ciphertext[0, 20]}
+  let(:invalid_nonce) { nonce[0, nonce.bytesize/2] } # too short!
+  let(:invalid_nonce_long) { nonce + nonce } # too long!
+  let(:nonce_error_regex) { /Nonce.*(Expected #{aead.nonce_bytes})/ }
+  let(:corrupt_ad) {ad.succ}
+  let(:trunc_ad) {ad[0, ad.bytesize/2]}
+
+  context "new" do
+    it "accepts strings" do
+      expect { RbNaCl::AEAD::Chacha20Poly1305.new(key) }.to_not raise_error
+    end
+
+    it "raises on a nil key" do
+      expect { RbNaCl::AEAD::Chacha20Poly1305.new(nil) }.to raise_error(TypeError)
+    end
+
+    it "raises on a short key" do
+      expect { RbNaCl::AEAD::Chacha20Poly1305.new("hello") }.to raise_error RbNaCl::LengthError
+    end
+
+    it "raises on a long key" do
+      expect { RbNaCl::AEAD::Chacha20Poly1305.new("hello" + key) }.to raise_error RbNaCl::LengthError
+    end
+  end
+
+  context "encrypt" do
+    it "encrypts a message" do
+      expect(aead.encrypt(nonce, message, ad)).to eq ciphertext
+    end
+
+    it "raises on a short nonce" do
+      expect { aead.encrypt(invalid_nonce, message, ad) }.to raise_error(RbNaCl::LengthError, nonce_error_regex)
+    end
+
+    it "raises on a long nonce" do
+      expect { aead.encrypt(invalid_nonce_long, message, ad) }.to raise_error(RbNaCl::LengthError, nonce_error_regex)
+    end
+  end
+
+  context "decrypt" do
+    it "decrypts a message" do
+      expect(aead.decrypt(nonce, ciphertext, ad)).to eq message
+    end
+
+    it "raises on a truncated message to decrypt" do
+      expect { aead.decrypt(nonce, trunc_ciphertext, ad) }.to raise_error(RbNaCl::CryptoError, /Decryption failed. Ciphertext failed verification./)
+    end
+
+    it "raises on a corrupt ciphertext" do
+      expect { aead.decrypt(nonce, corrupt_ciphertext, ad) }.to raise_error(RbNaCl::CryptoError, /Decryption failed. Ciphertext failed verification./)
+    end
+
+    it "raises when the additional data is truncated" do
+      expect { aead.decrypt(nonce, ciphertext, corrupt_ad) }.to raise_error(RbNaCl::CryptoError, /Decryption failed. Ciphertext failed verification./)
+    end
+
+    it "raises when the additional data is corrupt " do
+      expect { aead.decrypt(nonce, ciphertext, trunc_ad) }.to raise_error(RbNaCl::CryptoError, /Decryption failed. Ciphertext failed verification./)
+    end
+
+    it "raises on a short nonce" do
+      expect { aead.decrypt(invalid_nonce, message, ad) }.to raise_error(RbNaCl::LengthError, nonce_error_regex)
+    end
+
+    it "raises on a long nonce" do
+      expect { aead.decrypt(invalid_nonce_long, message, ad) }.to raise_error(RbNaCl::LengthError, nonce_error_regex)
+    end
+  end
+end

--- a/spec/shared/aead.rb
+++ b/spec/shared/aead.rb
@@ -1,6 +1,4 @@
 # encoding: binary
-require "spec_helper"
-
 RSpec.shared_examples "aead" do
   let(:corrupt_ciphertext) { ciphertext.succ}
   let(:trunc_ciphertext) { ciphertext[0, 20]}

--- a/spec/shared/aead.rb
+++ b/spec/shared/aead.rb
@@ -1,15 +1,7 @@
 # encoding: binary
 require "spec_helper"
 
-RSpec.describe RbNaCl::AEAD::Chacha20Poly1305 do
-  let(:key) {vector :aead_chacha20poly1305_orig_key}
-  let(:message) {vector :aead_chacha20poly1305_orig_message}
-  let(:nonce) {vector :aead_chacha20poly1305_orig_nonce}
-  let(:ad) {vector :aead_chacha20poly1305_orig_ad}
-  let(:ciphertext) {vector :aead_chacha20poly1305_orig_ciphertext}
-
-  let(:aead) { RbNaCl::AEAD::Chacha20Poly1305.new(key) }
-
+RSpec.shared_examples "aead" do
   let(:corrupt_ciphertext) { ciphertext.succ}
   let(:trunc_ciphertext) { ciphertext[0, 20]}
   let(:invalid_nonce) { nonce[0, nonce.bytesize/2] } # too short!
@@ -20,19 +12,19 @@ RSpec.describe RbNaCl::AEAD::Chacha20Poly1305 do
 
   context "new" do
     it "accepts strings" do
-      expect { RbNaCl::AEAD::Chacha20Poly1305.new(key) }.to_not raise_error
+      expect { described_class.new(key) }.to_not raise_error
     end
 
     it "raises on a nil key" do
-      expect { RbNaCl::AEAD::Chacha20Poly1305.new(nil) }.to raise_error(TypeError)
+      expect { described_class.new(nil) }.to raise_error(TypeError)
     end
 
     it "raises on a short key" do
-      expect { RbNaCl::AEAD::Chacha20Poly1305.new("hello") }.to raise_error RbNaCl::LengthError
+      expect { described_class.new("hello") }.to raise_error RbNaCl::LengthError
     end
 
     it "raises on a long key" do
-      expect { RbNaCl::AEAD::Chacha20Poly1305.new("hello" + key) }.to raise_error RbNaCl::LengthError
+      expect { described_class.new("hello" + key) }.to raise_error RbNaCl::LengthError
     end
   end
 

--- a/spec/shared/aead.rb
+++ b/spec/shared/aead.rb
@@ -38,6 +38,14 @@ RSpec.shared_examples "aead" do
     it "raises on a long nonce" do
       expect { aead.encrypt(invalid_nonce_long, message, ad) }.to raise_error(RbNaCl::LengthError, nonce_error_regex)
     end
+
+    it "works with an empty message" do
+      expect { aead.encrypt(nonce, nil, ad)}.to_not raise_error
+    end
+
+    it "works with an empty additional data" do
+      expect{ aead.encrypt(nonce, message, nil)}.to_not raise_error
+    end
   end
 
   context "decrypt" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,7 @@ require "shared/box"
 require "shared/authenticator"
 require "shared/key_equality"
 require "shared/serializable"
+require "shared/aead"
 
 def vector(name)
   [RbNaCl::TEST_VECTORS[name]].pack("H*")


### PR DESCRIPTION
Addresses Issue #107.

Includes both the original implementation and the IETF implementation. I've tried to follow the style of the other wrappers, but if you have any suggestions, let me know.
