### PR TITLE
Run JRuby first in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,9 @@ branches:
     - master
 
 rvm:
+  - jruby-9.1.6.0
   - 2.2.6
   - 2.3.3
-  - jruby-9.1.6.0
 
 env:
   - LIBSODIUM_VERSION=1.0.0  # Minimum supported


### PR DESCRIPTION
This slightly decreases overall build time by letting the other builds run in
parallel with the (longer) JRuby build