### PR TITLE
bugfix: prevent segfault if pwhash_str_verify is passed nil

### DIFF
--- a/lib/rbnacl/password_hash.rb
+++ b/lib/rbnacl/password_hash.rb
@@ -81,8 +81,8 @@ module RbNaCl
         if RbNaCl::Sodium::Version::ARGON2_SUPPORTED
           true
         else
-          raise NoMethodError, "argon2 requires libsodium version >= 1.0.9" \
-                               " (currently running #{RbNaCl::Sodium::Version::STRING})"
+          raise NotImplementedError, "argon2 requires libsodium version >= 1.0.9" \
+                                     " (currently running #{RbNaCl::Sodium::Version::STRING})"
         end
       end
     end

--- a/lib/rbnacl/password_hash/argon2.rb
+++ b/lib/rbnacl/password_hash/argon2.rb
@@ -126,6 +126,7 @@ module RbNaCl
       #
       # @return [String] argon2 digest string
       def digest_str(password)
+        raise ArgumentError, "password must be a String" unless password.is_a?(String)
         result = Util.zeros(STRBYTES)
 
         ok = self.class.pwhash_str(
@@ -144,6 +145,8 @@ module RbNaCl
       #
       # @return [boolean] true if password matches digest_string
       def self.digest_str_verify(password, digest_string)
+        raise ArgumentError, "password must be a String" unless password.is_a?(String)
+        raise ArgumentError, "digest_string must be a String" unless digest_string.is_a?(String)
         pwhash_str_verify(
           digest_string,
           password, password.bytesize


### PR DESCRIPTION
this prevents an unpleasant ruby segfault if you happen to pass nil as the digest to `PasswordHash.argon2_valid?(password, digest)`