### PR TITLE
Raise error on degenerate keys (fixes #152)

### DIFF
--- a/lib/rbnacl/group_elements/curve25519.rb
+++ b/lib/rbnacl/group_elements/curve25519.rb
@@ -18,6 +18,9 @@ module RbNaCl
       # Order of the standard group
       STANDARD_GROUP_ORDER = 2**252 + 27_742_317_777_372_353_535_851_937_790_883_648_493
 
+      # Degenerate key (all-zeroes, results in an all-zero shared secret)
+      DEGENERATE_KEY = ("\0" * 32).freeze
+
       include KeyComparator
       include Serializable
 
@@ -44,6 +47,8 @@ module RbNaCl
       def initialize(point)
         @point = point.to_str
 
+        raise CryptoError, "degenerate key detected" if @point == DEGENERATE_KEY
+
         # FIXME: really should have a separate constant here for group element size
         # Group elements and scalars are both 32-bits, but that's for convenience
         Util.check_length(@point, SCALARBYTES, "group element")
@@ -61,11 +66,9 @@ module RbNaCl
         Util.check_length(integer, SCALARBYTES, "integer")
 
         result = Util.zeros(SCALARBYTES)
-        if self.class.scalarmult_curve25519(result, integer, @point)
-          self.class.new(result)
-        else 
-          raise CryptoError, "Invalid curve25519 result"
-        end
+
+        raise CryptoError, "degenerate key detected" unless self.class.scalarmult_curve25519(result, integer, @point)
+        self.class.new(result)
       end
 
       # Return the point serialized as bytes
@@ -81,6 +84,7 @@ module RbNaCl
       #
       # @return [RbNaCl::Point] standard base point (a.k.a. standard group element)
       def self.base
+        # TODO: better support fixed-based scalar multiplication (this glosses over native support)
         @base_point
       end
       class << self

--- a/lib/rbnacl/group_elements/curve25519.rb
+++ b/lib/rbnacl/group_elements/curve25519.rb
@@ -61,9 +61,11 @@ module RbNaCl
         Util.check_length(integer, SCALARBYTES, "integer")
 
         result = Util.zeros(SCALARBYTES)
-        self.class.scalarmult_curve25519(result, integer, @point)
-
-        self.class.new(result)
+        if self.class.scalarmult_curve25519(result, integer, @point)
+          self.class.new(result)
+        else 
+          raise CryptoError, "Invalid curve25519 result"
+        end
       end
 
       # Return the point serialized as bytes

--- a/spec/rbnacl/group_element_spec.rb
+++ b/spec/rbnacl/group_element_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe RbNaCl::GroupElement do
 
   let(:alice_mult_bob) { vector :alice_mult_bob }
 
+  let(:degenerate_key) { RbNaCl::GroupElements::Curve25519::DEGENERATE_KEY }
+
   subject { described_class.new(bob_public) }
 
   it "multiplies integers with the base point" do
@@ -21,6 +23,10 @@ RSpec.describe RbNaCl::GroupElement do
 
   it "serializes to bytes" do
     expect(subject.to_bytes).to eq bob_public
+  end
+
+  it "detects degenerate keys" do
+    expect { described_class.new(degenerate_key).mult(alice_private) }.to raise_error RbNaCl::CryptoError
   end
 
   include_examples "serializable"


### PR DESCRIPTION
(Picking up on @paragonie-scott's work from #153)

This fixes the RuboCop errors from @paragonie-scott's #153 PR, adds a test, and adopts a belt-and-suspenders approach by trying to detect degenerate keys eagerly (still also handling errors surfaced from libsodium itself)