### PR TITLE
Add ruby 2.4.2 to the supported versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ versions:
 
 * Ruby 2.2.6+
 * Ruby 2.3.0+
+* Ruby 2.4.2+
 * JRuby 9.1.6.0+
 
 If something doesn't work on one of these versions, it's a bug.


### PR DESCRIPTION
Since ruby 2.4.2 is run on travis, it should be safe to assume it's supported. So let's add it to the readme.