### PR TITLE
Add ruby 3.0 as test targets and drop ruby 2.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ before_install: sudo apt-get install libsodium18
 
 rvm:
   - jruby-9.2.8.0
-  - 2.5
   - 2.6
   - 2.7
+  - 3.0
 
 matrix:
   fast_finish: true

--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ You can use RbNaCl on platforms libsodium is supported (see below).
 This library aims to support and is [tested against][travis] the following Ruby
 versions:
 
-* Ruby 2.5
 * Ruby 2.6
 * Ruby 2.7
+* Ruby 3.0
 * JRuby 9.2
 
 If something doesn't work on one of these versions, it's a bug.


### PR DESCRIPTION
Test on Ruby 3.0. Ruby2.5 has been removed from the target because it is no longer supported.